### PR TITLE
[feat] 엔티티 클래스 매핑

### DIFF
--- a/doorip-domain/src/main/java/org/doorip/todo/domain/Allocator.java
+++ b/doorip-domain/src/main/java/org/doorip/todo/domain/Allocator.java
@@ -1,0 +1,24 @@
+package org.doorip.todo.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.doorip.common.BaseTimeEntity;
+import org.doorip.trip.domain.Participant;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Entity
+public class Allocator extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "allocator_id")
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id")
+    private Todo todo;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "todo_id")
+    private Participant participant;
+}

--- a/doorip-domain/src/main/java/org/doorip/todo/domain/Progress.java
+++ b/doorip-domain/src/main/java/org/doorip/todo/domain/Progress.java
@@ -1,0 +1,5 @@
+package org.doorip.todo.domain;
+
+public enum Progress {
+    INCOMPLETE, COMPLETE
+}

--- a/doorip-domain/src/main/java/org/doorip/todo/domain/Secret.java
+++ b/doorip-domain/src/main/java/org/doorip/todo/domain/Secret.java
@@ -1,0 +1,5 @@
+package org.doorip.todo.domain;
+
+public enum Secret {
+    OUR, MY
+}

--- a/doorip-domain/src/main/java/org/doorip/todo/domain/Todo.java
+++ b/doorip-domain/src/main/java/org/doorip/todo/domain/Todo.java
@@ -1,0 +1,38 @@
+package org.doorip.todo.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.doorip.common.BaseTimeEntity;
+import org.doorip.trip.domain.Trip;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Entity
+public class Todo extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "todo_id")
+    private Long id;
+    @Column(nullable = false)
+    private String title;
+    private LocalDate endDate;
+    private String memo;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Secret secret;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Progress progress;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+    @Builder.Default
+    @OneToMany(mappedBy = "todo", cascade = CascadeType.REMOVE)
+    private List<Allocator> allocators = new ArrayList<>();
+}

--- a/doorip-domain/src/main/java/org/doorip/trip/domain/Participant.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/domain/Participant.java
@@ -1,0 +1,40 @@
+package org.doorip.trip.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.doorip.common.BaseTimeEntity;
+import org.doorip.todo.domain.Allocator;
+import org.doorip.user.domain.User;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Entity
+public class Participant extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "participant_id")
+    private Long id;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+    @Column(nullable = false)
+    private Integer styleA;
+    @Column(nullable = false)
+    private Integer styleB;
+    @Column(nullable = false)
+    private Integer styleC;
+    @Column(nullable = false)
+    private Integer styleD;
+    @Column(nullable = false)
+    private Integer styleE;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "trip_id")
+    private Trip trip;
+    @OneToOne(mappedBy = "participant", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    private Allocator allocator;
+}

--- a/doorip-domain/src/main/java/org/doorip/trip/domain/Role.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/domain/Role.java
@@ -1,0 +1,5 @@
+package org.doorip.trip.domain;
+
+public enum Role {
+    HOST, PARTICIPATION
+}

--- a/doorip-domain/src/main/java/org/doorip/trip/domain/Trip.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/domain/Trip.java
@@ -1,0 +1,36 @@
+package org.doorip.trip.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.doorip.common.BaseTimeEntity;
+import org.doorip.todo.domain.Todo;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Entity
+public class Trip extends BaseTimeEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "trip_id")
+    private Long id;
+    @Column(nullable = false)
+    private String title;
+    @Column(nullable = false)
+    private LocalDate startDate;
+    @Column(nullable = false)
+    private LocalDate endDate;
+    @Column(nullable = false)
+    private String code;
+    @Builder.Default
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.REMOVE)
+    private List<Participant> participants = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "trip", cascade = CascadeType.REMOVE)
+    private List<Todo> todos = new ArrayList<>();
+}

--- a/doorip-domain/src/main/java/org/doorip/user/domain/Platform.java
+++ b/doorip-domain/src/main/java/org/doorip/user/domain/Platform.java
@@ -1,0 +1,5 @@
+package org.doorip.user.domain;
+
+public enum Platform {
+    KAKAO, APPLE
+}

--- a/doorip-domain/src/main/java/org/doorip/user/domain/User.java
+++ b/doorip-domain/src/main/java/org/doorip/user/domain/User.java
@@ -1,0 +1,36 @@
+package org.doorip.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.doorip.common.BaseTimeEntity;
+import org.doorip.trip.domain.Participant;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@Table(name = "users")
+@Entity
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    @Column(nullable = false)
+    private String intro;
+    private Integer result;
+    @Column(nullable = false)
+    private String platformId;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Platform platform;
+    private String refreshToken;
+    @Builder.Default
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private List<Participant> participants = new ArrayList<>();
+}


### PR DESCRIPTION
## Related Issue 📌
- close #6 

## Description ✔️
- User Entity 클래스를 구현하였습니다. (Database 'user' 예약어로 인해 Entity는 User, Table은 users로 지정했습니다.)
- Participant Entity 클래스를 구현하였습니다.
- Trip Entity 클래스를 구현하였습니다.
- Todo Entity 클래스를 구현하였습니다.
- Allocator Entity 클래스를 구현하였습니다.
- Setter 어노테이션은 의도가 불명확하고 변경하면 안 되는 값을 변경할 여지가 있기 때문에 안정성을 보장할 수 없어서 열어두지 않았습니다. 수정자가 필요한 경우 변경 의도를 확인할 수 있는 의미 있는 이름의 메서드를 추가하여 사용하면 좋을 것 같습니다.
- 매개 변수가 많아져도 높은 가독성 유지가 가능하고 필요한 데이터만 추가할 수 있도록 Builder 어노테이션을 적용하였습니다. 또한, 엔티티 내부에서 정적 생성 메서드를 활용하여 엔티티 생성을 제한하고 관리할 수 있도록 설계하면 좋을 것 같아 접근 레벨을 private으로 지정하였습니다. 동일한 이유로 AllArgsConstructor 어노테이션의 접근 레벨도 private으로 지정하였습니다.
- JPA 기본 스펙 상 기본 생성자를 요구하기 때문에 NoArgsConstructor 어노테이션을 적용하였습니다. 또한, 여러 위치에서 무분별한 엔티티 객체 생성을 방지하고 지연 로딩의 경우 프록시 객체가 해당 엔티티 클래스를 상속받을 수 있도록 접근 레벨을 private이 아닌 protected로 지정하였습니다.