### PR TITLE
[feat] 소셜 로그인 OpenFeign 관련 세팅

### DIFF
--- a/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
@@ -26,10 +26,10 @@ public enum ErrorMessage {
     MISMATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "e4017", "리프레시 토큰이 일치하지 않습니다."),
     INVALID_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "e4018", "애플 아이덴티티 토큰의 형식이 올바르지 않습니다."),
     INVALID_IDENTITY_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "e4019", "애플 아이덴티티 토큰의 값이 올바르지 않습니다."),
-    UNABLE_TO_CREATE_APPLE_PUBLIC_KEY(HttpStatus.UNAUTHORIZED, "e4020", "애플 로그인 중 퍼블릭 키 생성에 문제가 발생했습니다."),
-    EXPIRED_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "e4021", "애플 로그인 중 아이덴티티 토큰의 유효 기간이 만료되었습니다."),
-    INVALID_IDENTITY_TOKEN_CLAIMS(HttpStatus.UNAUTHORIZED, "e4022", "애플 아이덴터티 토큰의 클레임 값이 올바르지 않습니다."),
-    INVALID_KAKAO_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "e4023", "카카오 액세스 토큰의 정보를 조회하는 과정에서 오류가 발생하였습니다."),
+    UNABLE_TO_CREATE_APPLE_PUBLIC_KEY(HttpStatus.UNAUTHORIZED, "e40110", "애플 로그인 중 퍼블릭 키 생성에 문제가 발생했습니다."),
+    EXPIRED_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "e40111", "애플 로그인 중 아이덴티티 토큰의 유효 기간이 만료되었습니다."),
+    INVALID_IDENTITY_TOKEN_CLAIMS(HttpStatus.UNAUTHORIZED, "e40112", "애플 아이덴터티 토큰의 클레임 값이 올바르지 않습니다."),
+    INVALID_KAKAO_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "e40113", "카카오 액세스 토큰의 정보를 조회하는 과정에서 오류가 발생하였습니다."),
 
     /**
      * 403 Forbidden

--- a/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
@@ -24,6 +24,12 @@ public enum ErrorMessage {
     INVALID_REFRESH_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "e4015", "리프레시 토큰의 값이 올바르지 않습니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "e4016", "리프레시 토큰이 만료되었습니다. 다시 로그인해 주세요."),
     MISMATCH_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "e4017", "리프레시 토큰이 일치하지 않습니다."),
+    INVALID_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "e4018", "애플 아이덴티티 토큰의 형식이 올바르지 않습니다."),
+    INVALID_IDENTITY_TOKEN_VALUE(HttpStatus.UNAUTHORIZED, "e4019", "애플 아이덴티티 토큰의 값이 올바르지 않습니다."),
+    UNABLE_TO_CREATE_APPLE_PUBLIC_KEY(HttpStatus.UNAUTHORIZED, "e4020", "애플 로그인 중 퍼블릭 키 생성에 문제가 발생했습니다."),
+    EXPIRED_IDENTITY_TOKEN(HttpStatus.UNAUTHORIZED, "e4021", "애플 로그인 중 아이덴티티 토큰의 유효 기간이 만료되었습니다."),
+    INVALID_IDENTITY_TOKEN_CLAIMS(HttpStatus.UNAUTHORIZED, "e4022", "애플 아이덴터티 토큰의 클레임 값이 올바르지 않습니다."),
+    INVALID_KAKAO_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "e4023", "카카오 액세스 토큰의 정보를 조회하는 과정에서 오류가 발생하였습니다."),
 
     /**
      * 403 Forbidden

--- a/doorip-external/build.gradle
+++ b/doorip-external/build.gradle
@@ -1,4 +1,9 @@
 dependencies {
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.0.3'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     implementation project(path: ':doorip-common')
 }
 

--- a/doorip-external/src/main/java/org/doorip/config/FeignClientConfig.java
+++ b/doorip-external/src/main/java/org/doorip/config/FeignClientConfig.java
@@ -1,0 +1,10 @@
+package org.doorip.config;
+
+import org.doorip.ExternalRoot;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableFeignClients(basePackageClasses = ExternalRoot.class)
+public class FeignClientConfig {
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleFeignClient.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleFeignClient.java
@@ -1,0 +1,10 @@
+package org.doorip.openfeign.apple;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "${oauth.apple.name}", url = "${oauth.apple.url}")
+public interface AppleFeignClient {
+    @GetMapping("/keys")
+    ApplePublicKeys getApplePublicKeys();
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleIdentityTokenParser.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleIdentityTokenParser.java
@@ -1,0 +1,48 @@
+package org.doorip.openfeign.apple;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import org.doorip.exception.UnauthorizedException;
+import org.doorip.message.ErrorMessage;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.security.PublicKey;
+import java.util.Base64;
+import java.util.Map;
+
+
+@Component
+public class AppleIdentityTokenParser {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String encoded = identityToken.split("\\.")[0];;
+            String decoded = new String(Base64.getUrlDecoder().decode(encoded), StandardCharsets.UTF_8);
+            return OBJECT_MAPPER.readValue(decoded, Map.class);
+        } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {
+            throw new UnauthorizedException(ErrorMessage.INVALID_IDENTITY_TOKEN);
+        }
+    }
+
+    public Claims parseWithPublicKeyAndGetClaims(String identityToken, PublicKey publicKey) {
+        try {
+            return getJwtParser(publicKey)
+                    .parseClaimsJws(identityToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new UnauthorizedException(ErrorMessage.EXPIRED_IDENTITY_TOKEN);
+        } catch (UnsupportedJwtException | MalformedJwtException | IllegalArgumentException e) {
+            throw new UnauthorizedException(ErrorMessage.INVALID_IDENTITY_TOKEN_VALUE);
+        }
+    }
+
+    private JwtParser getJwtParser(Key key) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build();
+    }
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleIdentityTokenParser.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleIdentityTokenParser.java
@@ -20,7 +20,7 @@ public class AppleIdentityTokenParser {
 
     public Map<String, String> parseHeaders(String identityToken) {
         try {
-            String encoded = identityToken.split("\\.")[0];;
+            String encoded = identityToken.split("\\.")[0];
             String decoded = new String(Base64.getUrlDecoder().decode(encoded), StandardCharsets.UTF_8);
             return OBJECT_MAPPER.readValue(decoded, Map.class);
         } catch (JsonProcessingException | ArrayIndexOutOfBoundsException e) {

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleIdentityTokenParser.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleIdentityTokenParser.java
@@ -13,7 +13,6 @@ import java.security.PublicKey;
 import java.util.Base64;
 import java.util.Map;
 
-
 @Component
 public class AppleIdentityTokenParser {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleIdentityTokenValidator.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleIdentityTokenValidator.java
@@ -1,0 +1,18 @@
+package org.doorip.openfeign.apple;
+
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppleIdentityTokenValidator {
+    @Value("${oauth.apple.iss}")
+    private String iss;
+    @Value("${oauth.apple.client-id}")
+    private String clientId;
+
+    public boolean isValidAppleIdentityToken(Claims claims) {
+        return claims.getIssuer().contains(iss)
+                && claims.getAudience().equals(clientId);
+    }
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleOAuthProvider.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/AppleOAuthProvider.java
@@ -1,0 +1,35 @@
+package org.doorip.openfeign.apple;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.doorip.exception.UnauthorizedException;
+import org.doorip.message.ErrorMessage;
+import org.springframework.stereotype.Component;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class AppleOAuthProvider {
+    private final AppleFeignClient appleFeignClient;
+    private final AppleIdentityTokenParser appleIdentityTokenParser;
+    private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final AppleIdentityTokenValidator appleIdentityTokenValidator;
+
+    public String getApplePlatformId(String identityToken) {
+        Map<String, String> headers = appleIdentityTokenParser.parseHeaders(identityToken);
+        ApplePublicKeys applePublicKeys = appleFeignClient.getApplePublicKeys();
+        PublicKey publicKey = applePublicKeyGenerator.generatePublicKeyWithApplePublicKeys(headers, applePublicKeys);
+        Claims claims = appleIdentityTokenParser.parseWithPublicKeyAndGetClaims(identityToken, publicKey);
+        validateClaims(claims);
+
+        return claims.getSubject();
+    }
+
+    private void validateClaims(Claims claims) {
+        if (!appleIdentityTokenValidator.isValidAppleIdentityToken(claims)) {
+            throw new UnauthorizedException(ErrorMessage.INVALID_IDENTITY_TOKEN_CLAIMS);
+        }
+    }
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/ApplePublicKey.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/ApplePublicKey.java
@@ -1,0 +1,11 @@
+package org.doorip.openfeign.apple;
+
+public record ApplePublicKey(
+        String kty,
+        String kid,
+        String use,
+        String alg,
+        String n,
+        String e) {
+}
+

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/ApplePublicKeyGenerator.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/ApplePublicKeyGenerator.java
@@ -1,0 +1,35 @@
+package org.doorip.openfeign.apple;
+
+import org.doorip.exception.UnauthorizedException;
+import org.doorip.message.ErrorMessage;
+import org.springframework.stereotype.Component;
+
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+import java.math.BigInteger;
+
+@Component
+public class ApplePublicKeyGenerator {
+    public PublicKey generatePublicKeyWithApplePublicKeys(Map<String, String> headers, ApplePublicKeys applePublicKeys) {
+        ApplePublicKey applePublicKey = applePublicKeys
+                .getMatchesKey(headers.get("alg"), headers.get("kid"));
+
+        byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.n());
+        byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.e());
+
+        RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(
+                new BigInteger(1, nBytes), new BigInteger(1, eBytes));
+
+        try {
+            KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.kty());
+            return keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new UnauthorizedException(ErrorMessage.UNABLE_TO_CREATE_APPLE_PUBLIC_KEY);
+        }
+    }
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/apple/ApplePublicKeys.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/apple/ApplePublicKeys.java
@@ -1,0 +1,17 @@
+package org.doorip.openfeign.apple;
+
+import org.doorip.exception.UnauthorizedException;
+import org.doorip.message.ErrorMessage;
+
+import java.util.List;
+
+public class ApplePublicKeys {
+    private List<ApplePublicKey> keys;
+
+    public ApplePublicKey getMatchesKey(String alg, String kid) {
+        return keys.stream()
+                .filter(applePublicKey -> applePublicKey.alg().equals(alg) && applePublicKey.kid().equals(kid))
+                .findFirst()
+                .orElseThrow(() -> new UnauthorizedException(ErrorMessage.INVALID_IDENTITY_TOKEN));
+    }
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoAccessToken.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoAccessToken.java
@@ -1,0 +1,20 @@
+package org.doorip.openfeign.kakao;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class KakaoAccessToken {
+    private static final String TOKEN_TYPE = "Bearer ";
+    private String accessToken;
+
+    public static KakaoAccessToken createKakaoAccessToken(String accessToken) {
+        return new KakaoAccessToken(accessToken);
+    }
+
+    public String getAccessTokenWithTokenType() {
+        return TOKEN_TYPE + accessToken;
+    }
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoAccessTokenInfo.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoAccessTokenInfo.java
@@ -1,0 +1,10 @@
+package org.doorip.openfeign.kakao;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public record KakaoAccessTokenInfo(
+        Long id
+) {
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoAccessTokenInfo.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoAccessTokenInfo.java
@@ -1,9 +1,5 @@
 package org.doorip.openfeign.kakao;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 public record KakaoAccessTokenInfo(
         Long id
 ) {

--- a/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoFeignClient.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoFeignClient.java
@@ -1,0 +1,12 @@
+package org.doorip.openfeign.kakao;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@FeignClient(name = "${oauth.kakao.name}", url = "${oauth.kakao.url}")
+public interface KakaoFeignClient {
+    @GetMapping
+    KakaoAccessTokenInfo getKakaoAccessTokenInfo(@RequestHeader("Authorization") String accessTokenWithTokenType);
+}
+

--- a/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoOAuthProvider.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/kakao/KakaoOAuthProvider.java
@@ -1,0 +1,31 @@
+package org.doorip.openfeign.kakao;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.doorip.exception.UnauthorizedException;
+import org.doorip.message.ErrorMessage;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KakaoOAuthProvider {
+    private final KakaoFeignClient kakaoFeignClient;
+
+    public String getKakaoPlatformId(String accessToken) {
+        KakaoAccessToken kakaoAccessToken = KakaoAccessToken.createKakaoAccessToken(accessToken);
+        String accessTokenWithTokenType = kakaoAccessToken.getAccessTokenWithTokenType();
+        KakaoAccessTokenInfo kakaoAccessTokenInfo = getKakaoAccessTokenInfo(accessTokenWithTokenType);
+        return String.valueOf(kakaoAccessTokenInfo.id());
+    }
+
+    private KakaoAccessTokenInfo getKakaoAccessTokenInfo(String accessTokenWithTokenType) {
+        try {
+            return kakaoFeignClient.getKakaoAccessTokenInfo(accessTokenWithTokenType);
+        } catch (FeignException e) {
+            log.error("Feign Exception: ", e);
+            throw new UnauthorizedException(ErrorMessage.INVALID_KAKAO_ACCESS_TOKEN);
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
- close #9 

## Description ✔️
- Open Feign 사용을 위한 FeignConfig를 구현하였습니다.
- 애플의 공개키들을 가져오기 위한 AppleFeignClient를 구현하였습니다.
- 애플 공개키 응답 dto, 카카오 응답 dto로 ApplePublicKey, KakaoAccessTokenInfo를 구현하였고, 데이터만 전송하는 역할만 가지고 있기 때문에 record로 구현하였습니다.
- 애플의 공개키들을 받아와 맞는 공개키를 가져오는 ApplePublicKeys를 구현하였습니다.
- 애플 공개키를 생성하는 ApplePublicKeyGenerator를 구현하였습니다.
- 애플의 Identity Token을 파싱하는 AppleIdentityTokenParser를 구현하였습니다.
- 애플의 Identity Token의 Claims를 검증하는 AppleIdentityTokenValidator를 구현하였습니다.
- 애플의 platform id를 제공받는 AppleOAuthProvider를 구현하였습니다.
- 카카오의 Access Token을 가져오기 위한 KakaoFeignClient를 구현하였습니다.
- 카카오의 Access Token 형식을 정의하기 위한 KakaoAccessToken를 구현하였습니다.
- 카카오의 platform id를 제공받는 KakaoOAuthProvider를 구현하였습니다.