### PR TITLE
[feat] 소셜 로그인 API 구현

### DIFF
--- a/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
+++ b/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
@@ -1,0 +1,25 @@
+package org.doorip.user.api;
+
+import lombok.RequiredArgsConstructor;
+import org.doorip.common.ApiResponse;
+import org.doorip.common.ApiResponseUtil;
+import org.doorip.message.SuccessMessage;
+import org.doorip.user.dto.request.UserSignInRequest;
+import org.doorip.user.dto.response.UserResponse;
+import org.doorip.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+@RestController
+public class UserApiController {
+    private final UserService userService;
+
+    @PostMapping("/signin")
+    public ResponseEntity<ApiResponse<?>> signIn(@RequestHeader("Authorization") final String token,
+                                                 @RequestParam final UserSignInRequest request) {
+        final UserResponse response = userService.signIn(token, request);
+        return ApiResponseUtil.success(SuccessMessage.OK, response);
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
+++ b/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
@@ -8,11 +8,12 @@ import org.doorip.user.dto.request.UserSignInRequest;
 import org.doorip.user.dto.response.UserResponse;
 import org.doorip.user.service.UserService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
-@RestController
+@Controller
 public class UserApiController {
     private final UserService userService;
 

--- a/doorip-api/src/main/java/org/doorip/user/dto/request/UserSignInRequest.java
+++ b/doorip-api/src/main/java/org/doorip/user/dto/request/UserSignInRequest.java
@@ -1,0 +1,6 @@
+package org.doorip.user.dto.request;
+
+public record UserSignInRequest(
+        String platform
+) {
+}

--- a/doorip-api/src/main/java/org/doorip/user/dto/response/UserResponse.java
+++ b/doorip-api/src/main/java/org/doorip/user/dto/response/UserResponse.java
@@ -1,0 +1,16 @@
+package org.doorip.user.dto.response;
+
+import org.doorip.auth.jwt.Token;
+
+public record UserResponse(
+        String accessToken,
+        String refreshToken
+) {
+
+    public static UserResponse of(Token token) {
+        return new UserResponse(
+                token.accessToken(),
+                token.refreshToken()
+        );
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/user/service/UserService.java
+++ b/doorip-api/src/main/java/org/doorip/user/service/UserService.java
@@ -1,0 +1,59 @@
+package org.doorip.user.service;
+
+import lombok.RequiredArgsConstructor;
+import org.doorip.auth.jwt.JwtProvider;
+import org.doorip.auth.jwt.Token;
+import org.doorip.exception.EntityNotFoundException;
+import org.doorip.message.ErrorMessage;
+import org.doorip.openfeign.apple.AppleOAuthProvider;
+import org.doorip.openfeign.kakao.KakaoOAuthProvider;
+import org.doorip.user.domain.Platform;
+import org.doorip.user.domain.RefreshToken;
+import org.doorip.user.domain.User;
+import org.doorip.user.dto.request.UserSignInRequest;
+import org.doorip.user.dto.response.UserResponse;
+import org.doorip.user.repository.RefreshTokenRepository;
+import org.doorip.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.doorip.user.domain.Platform.APPLE;
+import static org.doorip.user.domain.Platform.getEnumPlatformFromStringPlatform;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtProvider jwtProvider;
+    private final AppleOAuthProvider appleOAuthProvider;
+    private final KakaoOAuthProvider kakaoOAuthProvider;
+
+    public UserResponse signIn(String token, UserSignInRequest request) {
+        Platform enumPlatform = getEnumPlatformFromStringPlatform(request.platform());
+        String platformId = getPlatformId(token, enumPlatform);
+        User findUser = getUser(enumPlatform, platformId);
+        Token issueToken = jwtProvider.issueToken(findUser.getId());
+        updateRefreshToken(issueToken.refreshToken(), findUser);
+
+        return UserResponse.of(issueToken);
+    }
+
+    private String getPlatformId(String token, Platform platform) {
+        if (platform == APPLE) {
+            return appleOAuthProvider.getApplePlatformId(token);
+        }
+        return kakaoOAuthProvider.getKakaoPlatformId(token);
+    }
+
+    private User getUser(Platform platform, String platformId) {
+        return userRepository.findUserByPlatformAndPlatformId(platform, platformId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.USER_NOT_FOUND));
+    }
+
+    private void updateRefreshToken(String refreshToken, User user) {
+        user.updateRefreshToken(refreshToken);
+        refreshTokenRepository.save(RefreshToken.createRefreshToken(user.getId(), refreshToken));
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/user/service/UserService.java
+++ b/doorip-api/src/main/java/org/doorip/user/service/UserService.java
@@ -30,6 +30,7 @@ public class UserService {
     private final AppleOAuthProvider appleOAuthProvider;
     private final KakaoOAuthProvider kakaoOAuthProvider;
 
+    @Transactional
     public UserResponse signIn(String token, UserSignInRequest request) {
         Platform enumPlatform = getEnumPlatformFromStringPlatform(request.platform());
         String platformId = getPlatformId(token, enumPlatform);

--- a/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
@@ -12,6 +12,7 @@ public enum ErrorMessage {
      * 400 Bad Request
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "e4000", "잘못된 요청입니다."),
+    INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "e4001", "유효하지 않은 플랫폼 타입입니다."),
 
     /**
      * 401 Unauthorized
@@ -40,6 +41,7 @@ public enum ErrorMessage {
      * 404 Not Found
      */
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "e4040", "대상을 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "e4041", "존재하지 않는 회원입니다."),
 
     /**
      * 405 Method Not Allowed

--- a/doorip-domain/build.gradle
+++ b/doorip-domain/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation project(path: ':doorip-common')

--- a/doorip-domain/src/main/java/org/doorip/user/domain/Platform.java
+++ b/doorip-domain/src/main/java/org/doorip/user/domain/Platform.java
@@ -1,5 +1,23 @@
 package org.doorip.user.domain;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import org.doorip.exception.InvalidValueException;
+import org.doorip.message.ErrorMessage;
+
+import java.util.Arrays;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum Platform {
-    KAKAO, APPLE
+    APPLE("apple"),
+    KAKAO("kakao");
+
+    private final String stringPlatform;
+
+    public static Platform getEnumPlatformFromStringPlatform(String stringPlatform) {
+        return Arrays.stream(values())
+                .filter(platform -> platform.stringPlatform.equals(stringPlatform))
+                .findFirst()
+                .orElseThrow(() -> new InvalidValueException(ErrorMessage.INVALID_PLATFORM_TYPE));
+    }
 }

--- a/doorip-domain/src/main/java/org/doorip/user/domain/RefreshToken.java
+++ b/doorip-domain/src/main/java/org/doorip/user/domain/RefreshToken.java
@@ -1,0 +1,25 @@
+package org.doorip.user.domain;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 604800000)
+public class RefreshToken {
+    @Id
+    private Long id;
+    private String refreshToken;
+
+    public static RefreshToken createRefreshToken(Long userId, String refreshToken) {
+        return RefreshToken.builder()
+                .id(userId)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/doorip-domain/src/main/java/org/doorip/user/domain/User.java
+++ b/doorip-domain/src/main/java/org/doorip/user/domain/User.java
@@ -33,4 +33,8 @@ public class User extends BaseTimeEntity {
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<Participant> participants = new ArrayList<>();
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
 }

--- a/doorip-domain/src/main/java/org/doorip/user/repository/RefreshTokenRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package org.doorip.user.repository;
+
+import org.doorip.user.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+}

--- a/doorip-domain/src/main/java/org/doorip/user/repository/UserRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package org.doorip.user.repository;
+
+import org.doorip.user.domain.Platform;
+import org.doorip.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findUserByPlatformAndPlatformId(Platform platform, String platformId);
+}


### PR DESCRIPTION
## Related Issue 📌
close #14 

## Description ✔️
- 소셜 로그인 비즈니스 로직인 UserService 클래스를 구현하였습니다.
- UserController 클래스를 구현하였습니다.
- UserRepository 클래스를 구현하였습니다.
- 로그인 요청, 응답 dto로 UserSignInRequest, UserResponse 클래스를 구현하였습니다.
- RefreshToken을 Redis에서 관리하기 위해 RefreshToken, RefreshTokenRepository 클래스를 구현하였습니다.
- string platform과 enum platform를 매핑해주는 getEnumPlatformFromStringPlatform 메서드를 구현하였습니다.
