### PR TITLE
[feat] Jwt 재발급 API 구현

### DIFF
--- a/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
+++ b/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
@@ -5,6 +5,7 @@ import org.doorip.auth.UserId;
 import org.doorip.common.ApiResponse;
 import org.doorip.common.ApiResponseUtil;
 import org.doorip.message.SuccessMessage;
+import org.doorip.user.dto.request.UserReissueRequest;
 import org.doorip.user.dto.request.UserSignInRequest;
 import org.doorip.user.dto.request.UserSignUpRequest;
 import org.doorip.user.dto.response.UserResponse;
@@ -43,5 +44,12 @@ public class UserApiController {
     public ResponseEntity<ApiResponse<?>> withdraw(@UserId final Long userId) {
         userService.withdraw(userId);
         return ApiResponseUtil.success(SuccessMessage.OK);
+    }
+
+    @PatchMapping("/reissue")
+    public ResponseEntity<ApiResponse<?>> reissue(@RequestHeader("Authorization") final String refreshtoken,
+                                                  @RequestBody final UserReissueRequest request) {
+        UserResponse response = userService.reissue(refreshtoken, request);
+        return ApiResponseUtil.success(SuccessMessage.OK, response);
     }
 }

--- a/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
+++ b/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
@@ -46,8 +46,8 @@ public class UserApiController {
         return ApiResponseUtil.success(SuccessMessage.OK);
     }
 
-    @PatchMapping("/reissue")
-    public ResponseEntity<ApiResponse<?>> reissue(@RequestHeader("Authorization") final String refreshtoken,
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<?>> reissue(@RequestHeader(AUTHORIZATION) final String refreshtoken,
                                                   @RequestBody final UserReissueRequest request) {
         UserResponse response = userService.reissue(refreshtoken, request);
         return ApiResponseUtil.success(SuccessMessage.OK, response);

--- a/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
+++ b/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
@@ -14,6 +14,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
+import static org.doorip.common.Constants.AUTHORIZATION;
+
 @RequiredArgsConstructor
 @RequestMapping("/api/users")
 @Controller
@@ -21,14 +23,14 @@ public class UserApiController {
     private final UserService userService;
 
     @PostMapping("/signin")
-    public ResponseEntity<ApiResponse<?>> signIn(@RequestHeader("Authorization") final String token,
+    public ResponseEntity<ApiResponse<?>> signIn(@RequestHeader(AUTHORIZATION) final String token,
                                                  @RequestBody final UserSignInRequest request) {
         final UserResponse response = userService.signIn(token, request);
         return ApiResponseUtil.success(SuccessMessage.OK, response);
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<ApiResponse<?>> signUp(@RequestHeader("Authorization") final String token,
+    public ResponseEntity<ApiResponse<?>> signUp(@RequestHeader(AUTHORIZATION) final String token,
                                                  @RequestBody final UserSignUpRequest request) {
         final UserResponse response = userService.signUp(token, request);
         return ApiResponseUtil.success(SuccessMessage.CREATED, response);

--- a/doorip-api/src/main/java/org/doorip/user/dto/request/UserReissueRequest.java
+++ b/doorip-api/src/main/java/org/doorip/user/dto/request/UserReissueRequest.java
@@ -1,0 +1,6 @@
+package org.doorip.user.dto.request;
+
+public record UserReissueRequest(
+        Long userId
+) {
+}

--- a/doorip-api/src/main/java/org/doorip/user/service/UserService.java
+++ b/doorip-api/src/main/java/org/doorip/user/service/UserService.java
@@ -2,14 +2,17 @@ package org.doorip.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.doorip.auth.jwt.JwtProvider;
+import org.doorip.auth.jwt.JwtValidator;
 import org.doorip.auth.jwt.Token;
 import org.doorip.exception.EntityNotFoundException;
+import org.doorip.exception.UnauthorizedException;
 import org.doorip.message.ErrorMessage;
 import org.doorip.openfeign.apple.AppleOAuthProvider;
 import org.doorip.openfeign.kakao.KakaoOAuthProvider;
 import org.doorip.user.domain.Platform;
 import org.doorip.user.domain.RefreshToken;
 import org.doorip.user.domain.User;
+import org.doorip.user.dto.request.UserReissueRequest;
 import org.doorip.user.dto.request.UserSignInRequest;
 import org.doorip.user.dto.request.UserSignUpRequest;
 import org.doorip.user.dto.response.UserResponse;
@@ -29,6 +32,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtProvider jwtProvider;
+    private final JwtValidator jwtValidator;
     private final AppleOAuthProvider appleOAuthProvider;
     private final KakaoOAuthProvider kakaoOAuthProvider;
 
@@ -61,6 +65,17 @@ public class UserService {
         userRepository.deleteById(userId);
     }
 
+    @Transactional(noRollbackFor = UnauthorizedException.class)
+    public UserResponse reissue(String refreshToken, UserReissueRequest request) {
+        Long userId = request.userId();
+        validateRefreshToken(refreshToken, userId);
+        User findUser = getUser(userId);
+        Token issueToken = jwtProvider.issueToken(userId);
+        updateRefreshToken(issueToken.refreshToken(), findUser);
+
+        return UserResponse.of(issueToken);
+    }
+
     private String getPlatformId(String token, Platform platform) {
         if (platform == APPLE) {
             return appleOAuthProvider.getApplePlatformId(token);
@@ -91,5 +106,31 @@ public class UserService {
     private void deleteRefreshToken(User user) {
         user.updateRefreshToken(null);
         refreshTokenRepository.deleteById(user.getId());
+    }
+
+    private void validateRefreshToken(String refreshToken, Long userId) {
+        try {
+            jwtValidator.validateRefreshToken(refreshToken);
+            String storedRefreshToken = getRefreshToken(userId);
+            jwtValidator.equalsRefreshToken(refreshToken, storedRefreshToken);
+        } catch (UnauthorizedException e) {
+            signOut(userId);
+            throw e;
+        }
+    }
+
+    private String getRefreshToken(Long userId) {
+        try {
+            return getRefreshTokenFromRedis(userId);
+        } catch (EntityNotFoundException e) {
+            User findUser = getUser(userId);
+            return findUser.getRefreshToken();
+        }
+    }
+
+    private String getRefreshTokenFromRedis(Long userId) {
+        RefreshToken storedRefreshToken = refreshTokenRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.REFRESH_TOKEN_NOT_FOUND));
+        return storedRefreshToken.getRefreshToken();
     }
 }

--- a/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
@@ -42,6 +42,7 @@ public enum ErrorMessage {
      */
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "e4040", "대상을 찾을 수 없습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "e4041", "존재하지 않는 회원입니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "e4042", "리프레쉬 토큰을 찾을 수 없습니다."),
 
     /**
      * 405 Method Not Allowed


### PR DESCRIPTION
## Related Issue 📌
close #20 

## Description ✔️
- UserService에 Jwt 재발급 비즈니스 로직을 구현하였습니다.
- UserApiController 클래스의 reissue 메서드를 구현하였습니다.
- Jwt 재발급 요청 dto로 UserReissueRequest를 구현하였습니다.