### PR TITLE
[feat] 여행 대시보드 전체 조회 API 구현

### DIFF
--- a/doorip-api/src/main/java/org/doorip/common/Constants.java
+++ b/doorip-api/src/main/java/org/doorip/common/Constants.java
@@ -4,4 +4,6 @@ public abstract class Constants {
     public static final String AUTHORIZATION = "Authorization";
     public static final String BEARER = "Bearer ";
     public static final String CHARACTER_TYPE = "utf-8";
+    public static final String INCOMPLETE = "incomplete";
+    public static final String COMPLETE = "complete";
 }

--- a/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
@@ -1,0 +1,27 @@
+package org.doorip.trip.api;
+
+import lombok.RequiredArgsConstructor;
+import org.doorip.auth.UserId;
+import org.doorip.common.ApiResponse;
+import org.doorip.common.ApiResponseUtil;
+import org.doorip.message.SuccessMessage;
+import org.doorip.trip.dto.response.TripGetResponse;
+import org.doorip.trip.service.TripService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/trips")
+@Controller
+public class TripApiController {
+    private final TripService tripService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<?>> getTrips(@UserId final Long userId, @RequestParam final String progress) {
+        final TripGetResponse response = tripService.getTrips(userId, progress);
+        return ApiResponseUtil.success(SuccessMessage.OK, response);
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripGetResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripGetResponse.java
@@ -1,0 +1,23 @@
+package org.doorip.trip.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.doorip.trip.domain.Trip;
+
+import java.util.List;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record TripGetResponse(
+        String name,
+        List<TripResponse> trips
+) {
+    public static TripGetResponse of(String name, List<Trip> trips) {
+        return TripGetResponse.builder()
+                .name(name)
+                .trips(trips.stream()
+                        .map(TripResponse::of)
+                        .toList())
+                .build();
+
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripResponse.java
@@ -1,0 +1,31 @@
+package org.doorip.trip.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.doorip.trip.domain.Trip;
+
+import java.time.LocalDate;
+
+import static java.time.Period.between;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record TripResponse(
+        Long tripId,
+        String title,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate startDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate endDate,
+        int day
+) {
+    public static TripResponse of(Trip trip) {
+        return TripResponse.builder()
+                .tripId(trip.getId())
+                .title(trip.getTitle())
+                .startDate(trip.getStartDate())
+                .endDate(trip.getEndDate())
+                .day(between(LocalDate.now(), trip.getStartDate()).getDays())
+                .build();
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/trip/service/TripService.java
+++ b/doorip-api/src/main/java/org/doorip/trip/service/TripService.java
@@ -1,0 +1,45 @@
+package org.doorip.trip.service;
+
+import lombok.RequiredArgsConstructor;
+import org.doorip.common.Constants;
+import org.doorip.exception.EntityNotFoundException;
+import org.doorip.exception.InvalidValueException;
+import org.doorip.message.ErrorMessage;
+import org.doorip.trip.domain.Trip;
+import org.doorip.trip.dto.response.TripGetResponse;
+import org.doorip.trip.repository.TripRepository;
+import org.doorip.user.domain.User;
+import org.doorip.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class TripService {
+    private final UserRepository userRepository;
+    private final TripRepository tripRepository;
+
+    public TripGetResponse getTrips(Long userId, String progress) {
+        User findUser = getUser(userId);
+        List<Trip> trips = getTripsAccordingToProgress(userId, progress);
+        return TripGetResponse.of(findUser.getName(), trips);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.USER_NOT_FOUND));
+    }
+
+    private List<Trip> getTripsAccordingToProgress(Long userId, String progress) {
+        if (progress.equals(Constants.INCOMPLETE)) {
+            return tripRepository.findInCompleteTripsByUserId(userId, LocalDate.now());
+        } else if (progress.equals(Constants.COMPLETE)) {
+            return tripRepository.findCompleteTripsByUserId(userId, LocalDate.now());
+        }
+        throw new InvalidValueException(ErrorMessage.INVALID_REQUEST_PARAMETER_VALUE);
+    }
+}

--- a/doorip-api/src/main/resources/db/migration/V2__ddl.sql
+++ b/doorip-api/src/main/resources/db/migration/V2__ddl.sql
@@ -1,0 +1,12 @@
+alter table participant drop foreign key participant_ibfk_1;
+drop index user_id on participant;
+alter table participant add constraint participant_ibfk_1 foreign key (user_id) references users (user_id);
+alter table participant drop foreign key participant_ibfk_2;
+drop index trip_id on participant;
+alter table participant add constraint participant_ibfk_2 foreign key (trip_id) references trip (trip_id);
+alter table todo drop foreign key todo_ibfk_1;
+drop index trip_id on todo;
+alter table todo add constraint todo_ibfk_1 foreign key (trip_id) references trip (trip_id);
+alter table allocator drop foreign key allocator_ibfk_2;
+drop index todo_id on allocator;
+alter table allocator add constraint allocator_ibfk_2 foreign key (todo_id) references todo (todo_id);

--- a/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
@@ -13,6 +13,7 @@ public enum ErrorMessage {
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "e4000", "잘못된 요청입니다."),
     INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "e4001", "유효하지 않은 플랫폼 타입입니다."),
+    INVALID_REQUEST_PARAMETER_VALUE(HttpStatus.BAD_REQUEST, "e4002", "유효하지 않은 요청 파라미터 값입니다."),
 
     /**
      * 401 Unauthorized

--- a/doorip-domain/src/main/java/org/doorip/trip/repository/TripRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/repository/TripRepository.java
@@ -1,0 +1,33 @@
+package org.doorip.trip.repository;
+
+import io.lettuce.core.dynamic.annotation.Param;
+import org.doorip.trip.domain.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+    @Query("select t " +
+            "from Trip t " +
+            "join Participant p " +
+            "on p.trip = t " +
+            "join User u " +
+            "on p.user = u " +
+            "where u.id = :userId " +
+            "and datediff(t.endDate, :now) >= 0 " +
+            "order by datediff(t.startDate, :now)")
+    List<Trip> findInCompleteTripsByUserId(@Param("userId") Long userId, @Param("now") LocalDate now);
+
+    @Query("select t " +
+            "from Trip t " +
+            "join Participant p " +
+            "on p.trip = t " +
+            "join User u " +
+            "on p.user = u " +
+            "where u.id = :userId " +
+            "and datediff(t.endDate, :now) < 0 " +
+            "order by datediff(:now, t.endDate)")
+    List<Trip> findCompleteTripsByUserId(@Param("userId") Long userId, @Param("now") LocalDate now);
+}


### PR DESCRIPTION
## Related Issue 📌
- close #26 

## Description ✔️
- 1:N 관계의 외래키에 적용된 unique 제약 조건을 제거하였습니다. 해당 데이터베이스 스키마의 변경사항은 flyway V2__ddl.sql 스크립트로 적용하였습니다.
- 여행 대시보드 전체 조회 쿼리를 구현하였습니다. 해당 쿼리는 현재 날짜와 비교하여 가장 최근 날짜의 여행이 우선순위로 정렬되도록 조건을 추가하였습니다.
- 여행 대시보드 전체 조회 비즈니스 로직을 구현하였습니다.
- 여행 대시보드 전체 조회 API를 구현하였습니다.
