### PR TITLE
[feat] 여행 생성 API 구현

### DIFF
--- a/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
@@ -1,0 +1,30 @@
+package org.doorip.trip.api;
+
+import lombok.RequiredArgsConstructor;
+import org.doorip.auth.UserId;
+import org.doorip.common.ApiResponse;
+import org.doorip.common.ApiResponseUtil;
+import org.doorip.message.SuccessMessage;
+import org.doorip.trip.dto.request.TripCreateRequest;
+import org.doorip.trip.dto.response.TripCreateResponse;
+import org.doorip.trip.service.TripService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/trips")
+@Controller
+public class TripApiController {
+
+    private final TripService tripService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<?>> createTrip(@UserId final Long userId,
+                                                     @RequestBody final TripCreateRequest request) {
+        TripCreateResponse response = tripService.createTripAndParticipant(userId, request);
+        return ApiResponseUtil.success(SuccessMessage.CREATED, response);
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/trip/dto/request/TripCreateRequest.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/request/TripCreateRequest.java
@@ -1,0 +1,19 @@
+package org.doorip.trip.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record TripCreateRequest(
+    String title,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    LocalDate startDate,
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+    LocalDate endDate,
+    int styleA,
+    int styleB,
+    int styleC,
+    int styleD,
+    int styleE
+) {
+}

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripCreateResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripCreateResponse.java
@@ -1,0 +1,31 @@
+package org.doorip.trip.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.doorip.trip.domain.Trip;
+
+import java.time.LocalDate;
+
+import static java.time.Period.between;
+
+public record TripCreateResponse(
+        Long tripId,
+        String title,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate startDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate endDate,
+        String code,
+        int day
+) {
+
+    public static TripCreateResponse of(Trip trip) {
+        return new TripCreateResponse(
+                trip.getId(),
+                trip.getTitle(),
+                trip.getStartDate(),
+                trip.getEndDate(),
+                trip.getCode(),
+                between(LocalDate.now(), trip.getStartDate()).getDays()
+        );
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/trip/service/TripService.java
+++ b/doorip-api/src/main/java/org/doorip/trip/service/TripService.java
@@ -1,0 +1,82 @@
+package org.doorip.trip.service;
+
+import lombok.RequiredArgsConstructor;
+import org.doorip.exception.EntityNotFoundException;
+import org.doorip.exception.InvalidValueException;
+import org.doorip.message.ErrorMessage;
+import org.doorip.trip.domain.Participant;
+import org.doorip.trip.domain.Role;
+import org.doorip.trip.domain.Trip;
+import org.doorip.trip.dto.request.TripCreateRequest;
+import org.doorip.trip.dto.response.TripCreateResponse;
+import org.doorip.trip.repository.ParticipantRepository;
+import org.doorip.trip.repository.TripRepository;
+import org.doorip.user.domain.User;
+import org.doorip.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.doorip.trip.domain.Participant.createParticipant;
+import static org.doorip.trip.domain.Trip.createTrip;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class TripService {
+    private final TripRepository tripRepository;
+    private final ParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TripCreateResponse createTripAndParticipant(Long userId, TripCreateRequest request) {
+        User findUser = getUser(userId);
+        validateDate(request);
+        String code = createCode(6);
+        Trip createdTrip = saveTrip(request, code);
+        saveParticipant(request.styleA(), request.styleB(), request.styleC(), request.styleD(), request.styleE(), findUser, createdTrip);
+
+        return TripCreateResponse.of(createdTrip);
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorMessage.USER_NOT_FOUND));
+    }
+
+    private void validateDate(TripCreateRequest request) {
+        if (request.endDate().isBefore(LocalDate.now()) || request.endDate().isBefore(request.startDate())) {
+            throw new InvalidValueException(ErrorMessage.INVALID_DATE_TYPE);
+        }
+    }
+
+    private String createCode(int num) {
+        String code;
+
+        do {
+            String uuid = UUID.randomUUID().toString();
+            System.out.println(uuid);
+            code = uuid.substring(0, num);
+
+        } while (validateDuplicateCode(code));
+
+        return code;
+    }
+
+    private boolean validateDuplicateCode(String code) {
+        return tripRepository.existsByCode(code);
+    }
+
+    private Trip saveTrip(TripCreateRequest request, String code) {
+        Trip trip = createTrip(request.title(), request.startDate(), request.endDate(), code);
+        return tripRepository.save(trip);
+    }
+
+    private void saveParticipant(int styleA, int styleB, int styleC, int styleD, int styleE,
+                                        User user, Trip trip) {
+        Participant participant = createParticipant(Role.HOST, styleA, styleB, styleC, styleD, styleE, user, trip);
+        participantRepository.save(participant);
+    }
+}

--- a/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
@@ -13,6 +13,7 @@ public enum ErrorMessage {
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "e4000", "잘못된 요청입니다."),
     INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "e4001", "유효하지 않은 플랫폼 타입입니다."),
+    INVALID_DATE_TYPE(HttpStatus.BAD_REQUEST, "e4002", "유효하지 않은 날짜 타입입니다."),
 
     /**
      * 401 Unauthorized

--- a/doorip-domain/src/main/java/org/doorip/trip/domain/Participant.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/domain/Participant.java
@@ -37,4 +37,29 @@ public class Participant extends BaseTimeEntity {
     private Trip trip;
     @OneToOne(mappedBy = "participant", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private Allocator allocator;
+
+    public static Participant createParticipant(Role role, int styleA, int styleB, int styleC,
+                                                int styleD, int styleE, User user, Trip trip){
+        Participant participant = Participant.builder()
+                .role(role)
+                .styleA(styleA)
+                .styleB(styleB)
+                .styleC(styleC)
+                .styleD(styleD)
+                .styleE(styleE)
+                .user(user)
+                .trip(trip)
+                .build();
+        participant.changeTrip(trip);
+
+        return participant;
+    }
+
+    public void changeTrip(Trip trip) {
+        if (this.trip != null) {
+            this.trip.removeParticipant(this);
+        }
+        this.trip = trip;
+        trip.addParticipant(this);
+    }
 }

--- a/doorip-domain/src/main/java/org/doorip/trip/domain/Trip.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/domain/Trip.java
@@ -33,4 +33,21 @@ public class Trip extends BaseTimeEntity {
     @Builder.Default
     @OneToMany(mappedBy = "trip", cascade = CascadeType.REMOVE)
     private List<Todo> todos = new ArrayList<>();
+
+    public static Trip createTrip(String title, LocalDate startDate, LocalDate endDate, String code) {
+        return Trip.builder()
+                .title(title)
+                .startDate(startDate)
+                .endDate(endDate)
+                .code(code)
+                .build();
+    }
+
+    public void addParticipant(Participant participant) {
+        participants.add(participant);
+    }
+
+    public void removeParticipant(Participant participant) {
+        participants.remove(participant);
+    }
 }

--- a/doorip-domain/src/main/java/org/doorip/trip/domain/Trip.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/domain/Trip.java
@@ -28,7 +28,7 @@ public class Trip extends BaseTimeEntity {
     @Column(nullable = false)
     private String code;
     @Builder.Default
-    @OneToMany(mappedBy = "trip", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "trip", cascade = {CascadeType.REMOVE, CascadeType.PERSIST})
     private List<Participant> participants = new ArrayList<>();
     @Builder.Default
     @OneToMany(mappedBy = "trip", cascade = CascadeType.REMOVE)

--- a/doorip-domain/src/main/java/org/doorip/trip/repository/ParticipantRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/repository/ParticipantRepository.java
@@ -1,0 +1,7 @@
+package org.doorip.trip.repository;
+
+import org.doorip.trip.domain.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+}

--- a/doorip-domain/src/main/java/org/doorip/trip/repository/TripRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/repository/TripRepository.java
@@ -1,0 +1,8 @@
+package org.doorip.trip.repository;
+
+import org.doorip.trip.domain.Trip;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TripRepository extends JpaRepository<Trip, Long> {
+    Boolean existsByCode(String code);
+}

--- a/doorip-domain/src/main/java/org/doorip/trip/repository/TripRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/repository/TripRepository.java
@@ -30,4 +30,6 @@ public interface TripRepository extends JpaRepository<Trip, Long> {
             "and datediff(t.endDate, :now) < 0 " +
             "order by datediff(:now, t.endDate)")
     List<Trip> findCompleteTripsByUserId(@Param("userId") Long userId, @Param("now") LocalDate now);
+
+    boolean existsByCode(String code);
 }


### PR DESCRIPTION
## Related Issue 📌
close #27

## Description ✔️
- TripService에 Trip과 Participant를 생성하는 비즈니스 로직을 구현하였습니다. getUser를 통해 User 검증을 하고, 가져온 User에 해당하는 Participant를 생성할 수 있도록 설계하였으며, UUID를 통해 랜덤으로 6자리 코드를 생성하여 Trip을 생성하도록 했습니다. 이전에 중복되는 코드를 사용하면 안되기에 중복 검증 메서드를 통해 코드를 생성할 수 있도록 do-while문을 사용해줬습니다. 또한, Trip에 endDate가 startDate보다 빠르거나 endDate가 오늘 날짜보다 빠른 경우를 검증하도록 구현했습니다.
- 여행 생성 요청, 응답 dto로 TripCreateRequest, TripCreateResponse를 구현하였습니다.
- TripController 클래스를 구현하였습니다.
- TripRepository, ParticipantRepository 클래스를 구현하였습니다.
- 여행 생성 메서드와 참가자 생성 메서드를 구현하였습니다.

