### PR TITLE
[chore] Todo 엔티티 마감일 속성 not null 설정

### DIFF
--- a/doorip-domain/src/main/java/org/doorip/trip/domain/Todo.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/domain/Todo.java
@@ -20,6 +20,7 @@ public class Todo extends BaseTimeEntity {
     private Long id;
     @Column(nullable = false)
     private String title;
+    @Column(nullable = false)
     private LocalDate endDate;
     private String memo;
     @Column(nullable = false)


### PR DESCRIPTION
## Related Issue 📌
- close #63 

## Description ✔️
- 여행 TODO 엔티티의 마감일 속성에 not null 제약 조건을 추가하였습니다.
