### PR TITLE
[fix] Period.Between 메서드 날짜 계산 오류 해결

### DIFF
--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripCreateResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripCreateResponse.java
@@ -1,12 +1,14 @@
 package org.doorip.trip.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Builder;
 import org.doorip.trip.domain.Trip;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
-import static java.time.Period.between;
-
+@Builder(access = AccessLevel.PRIVATE)
 public record TripCreateResponse(
         Long tripId,
         String title,
@@ -19,13 +21,13 @@ public record TripCreateResponse(
 ) {
 
     public static TripCreateResponse of(Trip trip) {
-        return new TripCreateResponse(
-                trip.getId(),
-                trip.getTitle(),
-                trip.getStartDate(),
-                trip.getEndDate(),
-                trip.getCode(),
-                between(LocalDate.now(), trip.getStartDate()).getDays()
-        );
+        return TripCreateResponse.builder()
+                .tripId(trip.getId())
+                .title(trip.getTitle())
+                .startDate(trip.getStartDate())
+                .endDate(trip.getEndDate())
+                .code(trip.getCode())
+                .day((int) ChronoUnit.DAYS.between(LocalDate.now(), trip.getStartDate()))
+                .build();
     }
 }

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripResponse.java
@@ -6,8 +6,7 @@ import lombok.Builder;
 import org.doorip.trip.domain.Trip;
 
 import java.time.LocalDate;
-
-import static java.time.Period.between;
+import java.time.temporal.ChronoUnit;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record TripResponse(
@@ -25,7 +24,7 @@ public record TripResponse(
                 .title(trip.getTitle())
                 .startDate(trip.getStartDate())
                 .endDate(trip.getEndDate())
-                .day(between(LocalDate.now(), trip.getStartDate()).getDays())
+                .day((int) ChronoUnit.DAYS.between(LocalDate.now(), trip.getStartDate()))
                 .build();
     }
 }


### PR DESCRIPTION
## Related Issue 📌
- close #74 

## Description ✔️
- Period.between 메서드는 날짜 비교 결과를 n년 n개월 n일로 나타내어 주기 때문에 예를 들어 2023년 1월 11일과 2024년 1월 11일을 비교했을 때 1년 0개월 0일로 계산됩니다. 따라서 해당 결괏값에서 getDays() 메서드를 호출하게 되면 0 값을 반환 받게 되어 날짜 차이가 31일이 넘는 경우를 처리할 수 없는 문제점이 있었습니다. 해당 문제를 ChronoUnit.DAYS.between 메서드를 사용하여 해결하였습니다.
