### PR TITLE
[feat] 회원가입 이벤트 디스코드 웹훅 기능 구현

### DIFF
--- a/doorip-api/src/main/java/org/doorip/user/service/UserService.java
+++ b/doorip-api/src/main/java/org/doorip/user/service/UserService.java
@@ -9,7 +9,9 @@ import org.doorip.exception.EntityNotFoundException;
 import org.doorip.exception.InvalidValueException;
 import org.doorip.exception.UnauthorizedException;
 import org.doorip.message.ErrorMessage;
+import org.doorip.message.EventMessage;
 import org.doorip.openfeign.apple.AppleOAuthProvider;
+import org.doorip.openfeign.discord.DiscordMessageProvider;
 import org.doorip.openfeign.kakao.KakaoOAuthProvider;
 import org.doorip.user.domain.*;
 import org.doorip.user.dto.request.ResultUpdateRequest;
@@ -43,6 +45,7 @@ public class UserService {
     private final JwtValidator jwtValidator;
     private final AppleOAuthProvider appleOAuthProvider;
     private final KakaoOAuthProvider kakaoOAuthProvider;
+    private final DiscordMessageProvider discordMessageProvider;
 
     @Transactional(readOnly = true)
     public void splash(Long userId) {
@@ -67,6 +70,7 @@ public class UserService {
         User savedUser = saveUser(request, platformId, enumPlatform);
         Token issueToken = jwtProvider.issueToken(savedUser.getId());
         updateRefreshToken(issueToken.refreshToken(), savedUser);
+        discordMessageProvider.sendMessage(EventMessage.SIGN_UP_EVENT);
         return UserSignUpResponse.of(issueToken, savedUser.getId());
     }
 
@@ -102,7 +106,6 @@ public class UserService {
         String stringResult = oneTypeResult(mappedIndex.subList(0, 3), "S", "A")
                 + oneTypeResult(mappedIndex.subList(3, 6), "R", "E")
                 + oneTypeResult(mappedIndex.subList(6, 9), "P", "I");
-
         Result result = getEnumResultFromStringResult(stringResult);
         findUser.updateResult(result);
     }

--- a/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
@@ -18,6 +18,7 @@ public enum ErrorMessage {
     INVALID_DATE_TYPE(HttpStatus.BAD_REQUEST, "e4004", "유효하지 않은 날짜 타입입니다."),
     INVALID_RESULT_TYPE(HttpStatus.BAD_REQUEST, "e4005", "유효하지 않은 성향 입력 값입니다."),
     INVALID_PARTICIPANT_COUNT(HttpStatus.BAD_REQUEST, "e4006", "여행에 입장할 수 있는 최대 인원은 6명입니다."),
+    INVALID_DISCORD_MESSAGE(HttpStatus.BAD_REQUEST, "e4007", "디스코드 메시지 전달에 실패했습니다."),
 
     /**
      * 401 Unauthorized

--- a/doorip-common/src/main/java/org/doorip/message/EventMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/EventMessage.java
@@ -1,0 +1,13 @@
+package org.doorip.message;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum EventMessage {
+    SIGN_UP_EVENT("doorip 서비스에 회원가입 이벤트가 발생했습니다. 🎉");
+
+    private final String message;
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/discord/DiscordFeignClient.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/discord/DiscordFeignClient.java
@@ -1,0 +1,12 @@
+package org.doorip.openfeign.discord;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name = "${discord.name}", url = "${discord.webhook-url}")
+public interface DiscordFeignClient {
+    @PostMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    void sendMessage(@RequestBody DiscordMessage discordMessage);
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/discord/DiscordMessage.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/discord/DiscordMessage.java
@@ -1,0 +1,9 @@
+package org.doorip.openfeign.discord;
+
+public record DiscordMessage(
+        String content
+) {
+    public static DiscordMessage createDiscordMessage(String message) {
+        return new DiscordMessage(message);
+    }
+}

--- a/doorip-external/src/main/java/org/doorip/openfeign/discord/DiscordMessageProvider.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/discord/DiscordMessageProvider.java
@@ -1,0 +1,29 @@
+package org.doorip.openfeign.discord;
+
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import org.doorip.exception.InvalidValueException;
+import org.doorip.message.ErrorMessage;
+import org.doorip.message.EventMessage;
+import org.springframework.stereotype.Component;
+
+import static org.doorip.openfeign.discord.DiscordMessage.createDiscordMessage;
+
+@RequiredArgsConstructor
+@Component
+public class DiscordMessageProvider {
+    private final DiscordFeignClient discordFeignClient;
+
+    public void sendMessage(EventMessage eventMessage) {
+        DiscordMessage discordMessage = createDiscordMessage(eventMessage.getMessage());
+        sendMessageToDiscord(discordMessage);
+    }
+
+    private void sendMessageToDiscord(DiscordMessage discordMessage) {
+        try {
+            discordFeignClient.sendMessage(discordMessage);
+        } catch (FeignException e) {
+            throw new InvalidValueException(ErrorMessage.INVALID_DISCORD_MESSAGE);
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
- close #119 

## Description ✔️
- 회원가입 이벤트가 트리거 되면 디스코드로 "doorip 서비스에 회원가입 이벤트가 발생했습니다. 🎉" 메시지가 전달되는 기능을 구현하였습니다.
- doorip 스프링 부트 서버에서 디스코드 서버로 메시지 전달 HTTP 통신을 하기 위해 open feign을 활용하였습니다.
<img width="467" alt="스크린샷 2024-02-16 오후 3 56 07" src="https://github.com/Team-Going/Going-Server/assets/81796317/76eaf014-f33d-488b-8a35-9ca23b65c4b1">
