### PR TITLE
[feat] 여행 나가기 API 구현

### DIFF
--- a/doorip-api/src/main/java/org/doorip/common/Constants.java
+++ b/doorip-api/src/main/java/org/doorip/common/Constants.java
@@ -17,4 +17,5 @@ public abstract class Constants {
     public static final int MAX_STYLE_RATE = 100;
     public static final int PROPENSITY_WEIGHT = 25;
     public static final int MAX_PARTICIPANT_COUNT = 6;
+    public static final int MIN_PARTICIPANT_COUNT = 1;
 }

--- a/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
@@ -2,8 +2,8 @@ package org.doorip.trip.api;
 
 import lombok.RequiredArgsConstructor;
 import org.doorip.auth.UserId;
-import org.doorip.common.BaseResponse;
 import org.doorip.common.ApiResponseUtil;
+import org.doorip.common.BaseResponse;
 import org.doorip.message.SuccessMessage;
 import org.doorip.trip.dto.request.TripCreateRequest;
 import org.doorip.trip.dto.request.TripEntryRequest;
@@ -88,8 +88,8 @@ public class TripApiController implements TripApi {
 
     @PatchMapping("/{tripId}")
     public ResponseEntity<BaseResponse<?>> updateTrip(@PathVariable final Long tripId,
-                                                     @UserId final Long userId,
-                                                     @RequestBody final TripUpdateRequest request) {
+                                                      @UserId final Long userId,
+                                                      @RequestBody final TripUpdateRequest request) {
         tripService.updateTrip(userId, tripId, request);
         return ApiResponseUtil.success(SuccessMessage.OK);
     }

--- a/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
@@ -2,8 +2,8 @@ package org.doorip.trip.api;
 
 import lombok.RequiredArgsConstructor;
 import org.doorip.auth.UserId;
-import org.doorip.common.BaseResponse;
 import org.doorip.common.ApiResponseUtil;
+import org.doorip.common.BaseResponse;
 import org.doorip.message.SuccessMessage;
 import org.doorip.trip.dto.request.TripCreateRequest;
 import org.doorip.trip.dto.request.TripEntryRequest;
@@ -76,5 +76,12 @@ public class TripApiController implements TripApi {
                                                            @PathVariable final Long tripId) {
         final TripParticipantGetResponse response = tripDetailService.getParticipants(userId, tripId);
         return ApiResponseUtil.success(SuccessMessage.OK, response);
+    }
+
+    @PatchMapping("/{tripId}")
+    public ResponseEntity<BaseResponse<?>> leaveTrip(@UserId final Long userId,
+                                                     @PathVariable final Long tripId) {
+        tripDetailService.leaveTrip(userId, tripId);
+        return ApiResponseUtil.success(SuccessMessage.OK);
     }
 }

--- a/doorip-api/src/main/java/org/doorip/trip/service/TodoService.java
+++ b/doorip-api/src/main/java/org/doorip/trip/service/TodoService.java
@@ -118,18 +118,18 @@ public class TodoService {
 
     private List<Todo> getOurTodosAccordingToProgress(Long tripId, String progress) {
         if (progress.equals(Constants.INCOMPLETE)) {
-            return todoRepository.findOurTodoByTripId(tripId, Secret.OUR, Progress.INCOMPLETE);
+            return todoRepository.findOurTodoByTripIdAndSecretAndProgress(tripId, Secret.OUR, Progress.INCOMPLETE);
         } else if (progress.equals(Constants.COMPLETE)) {
-            return todoRepository.findOurTodoByTripId(tripId, Secret.OUR, Progress.COMPLETE);
+            return todoRepository.findOurTodoByTripIdAndSecretAndProgress(tripId, Secret.OUR, Progress.COMPLETE);
         }
         throw new InvalidValueException(ErrorMessage.INVALID_REQUEST_PARAMETER_VALUE);
     }
 
     private List<Todo> getMyTodosAccordingToProgress(Long userId, Long tripId, String progress) {
         if (progress.equals(Constants.INCOMPLETE)) {
-            return todoRepository.findMyTodoByTripId(tripId, userId, Progress.INCOMPLETE);
+            return todoRepository.findMyTodoByTripIdAndUserIdAndProgress(tripId, userId, Progress.INCOMPLETE);
         } else if (progress.equals(Constants.COMPLETE)) {
-            return todoRepository.findMyTodoByTripId(tripId, userId, Progress.COMPLETE);
+            return todoRepository.findMyTodoByTripIdAndUserIdAndProgress(tripId, userId, Progress.COMPLETE);
         }
         throw new InvalidValueException(ErrorMessage.INVALID_REQUEST_PARAMETER_VALUE);
     }

--- a/doorip-domain/src/main/java/org/doorip/trip/repository/ParticipantRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/repository/ParticipantRepository.java
@@ -5,6 +5,10 @@ import org.doorip.trip.domain.Trip;
 import org.doorip.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
     boolean existsByUserAndTrip(User user, Trip trip);
+
+    Optional<Participant> findByUserAndTrip(User user, Trip trip);
 }

--- a/doorip-domain/src/main/java/org/doorip/trip/repository/TodoRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/repository/TodoRepository.java
@@ -19,7 +19,20 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             "and d.progress = :progress " +
             "and d.secret = :secret " +
             "order by d.endDate")
-    List<Todo> findOurTodoByTripId(@Param("tripId") Long tripId, @Param("secret") Secret secret, @Param("progress") Progress progress);
+    List<Todo> findOurTodoByTripIdAndSecretAndProgress(@Param("tripId") Long tripId, @Param("secret") Secret secret, @Param("progress") Progress progress);
+
+    @Query("select d " +
+            "from Todo d " +
+            "join Trip i " +
+            "on d.trip = i " +
+            "join Participant p " +
+            "on p.trip = i " +
+            "join User u " +
+            "on p.user = u " +
+            "where i.id = :tripId " +
+            "and u.id = :userId " +
+            "and d.secret = :secret")
+    List<Todo> findMyTodoByTripIdAndUserIdAndSecret(@Param("tripId") Long tripId, @Param("userId") Long userId, @Param("secret") Secret secret);
 
     @Query("select d " +
             "from Todo d " +
@@ -35,7 +48,7 @@ public interface TodoRepository extends JpaRepository<Todo, Long> {
             "and u.id = :userId " +
             "and d.progress = :progress " +
             "order by d.endDate")
-    List<Todo> findMyTodoByTripId(@Param("tripId") Long tripId, @Param("userId") Long userId, @Param("progress") Progress progress);
+    List<Todo> findMyTodoByTripIdAndUserIdAndProgress(@Param("tripId") Long tripId, @Param("userId") Long userId, @Param("progress") Progress progress);
 
     int countTodoByTripIdAndSecretAndProgress(Long tripId, Secret secret, Progress progress);
 


### PR DESCRIPTION
## Related Issue 📌
- close #123 

## Description ✔️
- 여행 나가기 API를 구현하였습니다.
- 비즈니스 로직은 다음과 같습니다. (Reference. 카카오톡 방 나가기)
- case 1. 특정 여행에 참여자가 2명 이상이라면 나가기를 선택한 참여자의 혼자 할일을 삭제하고 공통 할일에서 배정이 취소되도록 구현하였습니다.
- case 2. 특정 여행에 참여자가 1명 이라면 나가기를 선택한 참여자의 혼자 할일을 삭제하고 해당 여행이 삭제되도록 구현하였습니다. 또한, 특정 여행이 삭제될 때 해당 여행에 생성된 모든 할일들이 함께 삭제되도록 구현하였습니다.
