### PR TITLE
[feat] 여행 TODO 생성 API 스펙 및 비즈니스 로직 변경

### DIFF
--- a/doorip-api/src/main/java/org/doorip/trip/api/TodoApi.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TodoApi.java
@@ -30,7 +30,11 @@ public interface TodoApi {
                             content = @Content),
                     @ApiResponse(
                             responseCode = "400",
-                            description = "여행 TODO를 생성하기 위해 최소 1명 이상의 배정자가 필요합니다.",
+                            description = "여행 MY TODO의 배정자가 누락되었습니다.",
+                            content = @Content),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "여행 MY TODO의 배정자 번호가 잘못되었습니다.",
                             content = @Content),
                     @ApiResponse(
                             responseCode = "401",
@@ -60,7 +64,9 @@ public interface TodoApi {
                             responseCode = "500",
                             description = "서버 내부 오류입니다.",
                             content = @Content)})
-    ResponseEntity<BaseResponse<?>> createTripTodo(@PathVariable final Long tripId,
+    ResponseEntity<BaseResponse<?>> createTripTodo(@Parameter(hidden = true)
+                                                   @UserId final Long userId,
+                                                   @PathVariable final Long tripId,
                                                    @RequestBody final TodoCreateRequest request);
 
     @Operation(

--- a/doorip-api/src/main/java/org/doorip/trip/api/TodoApiController.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TodoApiController.java
@@ -23,9 +23,10 @@ public class TodoApiController implements TodoApi {
 
     @PostMapping("/{tripId}/todos")
     @Override
-    public ResponseEntity<BaseResponse<?>> createTripTodo(@PathVariable final Long tripId,
+    public ResponseEntity<BaseResponse<?>> createTripTodo(@UserId final Long userId,
+                                                          @PathVariable final Long tripId,
                                                           @RequestBody final TodoCreateRequest request) {
-        todoService.createTripTodo(tripId, request);
+        todoService.createTripTodo(userId, tripId, request);
         return ApiResponseUtil.success(SuccessMessage.CREATED);
     }
 

--- a/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/ErrorMessage.java
@@ -14,11 +14,12 @@ public enum ErrorMessage {
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "e4000", "잘못된 요청입니다."),
     INVALID_PLATFORM_TYPE(HttpStatus.BAD_REQUEST, "e4001", "유효하지 않은 플랫폼 타입입니다."),
     INVALID_REQUEST_PARAMETER_VALUE(HttpStatus.BAD_REQUEST, "e4002", "유효하지 않은 요청 파라미터 값입니다."),
-    INVALID_ALLOCATOR_COUNT(HttpStatus.BAD_REQUEST, "e4003", "여행 TODO를 생성하기 위해 최소 1명 이상의 배정자가 필요합니다."),
+    INVALID_ALLOCATOR_COUNT(HttpStatus.BAD_REQUEST, "e4003", "여행 MY TODO의 배정자가 누락되었습니다."),
     INVALID_DATE_TYPE(HttpStatus.BAD_REQUEST, "e4004", "유효하지 않은 날짜 타입입니다."),
     INVALID_RESULT_TYPE(HttpStatus.BAD_REQUEST, "e4005", "유효하지 않은 성향 입력 값입니다."),
     INVALID_PARTICIPANT_COUNT(HttpStatus.BAD_REQUEST, "e4006", "여행에 입장할 수 있는 최대 인원은 6명입니다."),
     INVALID_DISCORD_MESSAGE(HttpStatus.BAD_REQUEST, "e4007", "디스코드 메시지 전달에 실패했습니다."),
+    INVALID_ALLOCATOR_ID(HttpStatus.BAD_REQUEST, "e4008", "여행 MY TODO의 배정자 번호가 잘못되었습니다."),
 
     /**
      * 401 Unauthorized


### PR DESCRIPTION
## Related Issue 📌
- close #136 

## Description ✔️
- 2차 스프린트 기능 추가에 따른 변경 사항을 반영하였습니다.
- 여행 TODO를 생성하는 과정에서 MY TODO 생성 시 검증이 누락된 부분을 확인하였고 이를 추가하였습니다.
- case 1. OUR TODO는 배정자 0명 이상이면 생성할 수 있다.
- case 2. MY TODO(혼자 할일)는 배정자가 1명이어야 한다
- case 2-1. 1명의 배정자는 사용자 본인이어야 한다.
