### PR TITLE
[feat] 여행 TODO 수정 API 구현

### DIFF
--- a/doorip-api/src/main/java/org/doorip/trip/api/TodoApi.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TodoApi.java
@@ -9,7 +9,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.doorip.auth.UserId;
 import org.doorip.common.BaseResponse;
-import org.doorip.trip.dto.request.TodoCreateRequest;
+import org.doorip.trip.dto.request.TodoCreateAndUpdateRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -67,7 +67,7 @@ public interface TodoApi {
     ResponseEntity<BaseResponse<?>> createTripTodo(@Parameter(hidden = true)
                                                    @UserId final Long userId,
                                                    @PathVariable final Long tripId,
-                                                   @RequestBody final TodoCreateRequest request);
+                                                   @RequestBody final TodoCreateAndUpdateRequest request);
 
     @Operation(
             summary = "여행 TODO 전체 조회 API",

--- a/doorip-api/src/main/java/org/doorip/trip/api/TodoApiController.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TodoApiController.java
@@ -5,7 +5,7 @@ import org.doorip.auth.UserId;
 import org.doorip.common.ApiResponseUtil;
 import org.doorip.common.BaseResponse;
 import org.doorip.message.SuccessMessage;
-import org.doorip.trip.dto.request.TodoCreateRequest;
+import org.doorip.trip.dto.request.TodoCreateAndUpdateRequest;
 import org.doorip.trip.dto.response.TodoDetailGetResponse;
 import org.doorip.trip.dto.response.TodoGetResponse;
 import org.doorip.trip.service.TodoService;
@@ -25,7 +25,7 @@ public class TodoApiController implements TodoApi {
     @Override
     public ResponseEntity<BaseResponse<?>> createTripTodo(@UserId final Long userId,
                                                           @PathVariable final Long tripId,
-                                                          @RequestBody final TodoCreateRequest request) {
+                                                          @RequestBody final TodoCreateAndUpdateRequest request) {
         todoService.createTripTodo(userId, tripId, request);
         return ApiResponseUtil.success(SuccessMessage.CREATED);
     }
@@ -47,6 +47,15 @@ public class TodoApiController implements TodoApi {
                                                        @PathVariable final Long todoId) {
         final TodoDetailGetResponse response = todoService.getTripTodo(userId, tripId, todoId);
         return ApiResponseUtil.success(SuccessMessage.OK, response);
+    }
+
+    @PatchMapping("/{tripId}/todos/{todoId}")
+    public ResponseEntity<BaseResponse<?>> updateTripTodo(@UserId final Long userId,
+                                                          @PathVariable final Long tripId,
+                                                          @PathVariable final Long todoId,
+                                                          @RequestBody final TodoCreateAndUpdateRequest request) {
+        todoService.updateTripTodo(userId, tripId, todoId, request);
+        return ApiResponseUtil.success(SuccessMessage.OK);
     }
 
     @DeleteMapping("/todos/{todoId}")

--- a/doorip-api/src/main/java/org/doorip/trip/dto/request/TodoCreateAndUpdateRequest.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/request/TodoCreateAndUpdateRequest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDate;
 import java.util.List;
 
-public record TodoCreateRequest(
+public record TodoCreateAndUpdateRequest(
         String title,
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
         LocalDate endDate,

--- a/doorip-domain/src/main/java/org/doorip/trip/domain/Todo.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/domain/Todo.java
@@ -71,4 +71,11 @@ public class Todo extends BaseTimeEntity {
     public void incomplete() {
         this.progress = Progress.INCOMPLETE;
     }
+
+    public void updateTodo(String title, LocalDate endDate, String memo, Secret secret) {
+        this.title = title;
+        this.endDate = endDate;
+        this.memo = memo;
+        this.secret = secret;
+    }
 }

--- a/doorip-domain/src/main/java/org/doorip/trip/repository/AllocatorRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/trip/repository/AllocatorRepository.java
@@ -1,0 +1,11 @@
+package org.doorip.trip.repository;
+
+import org.doorip.trip.domain.Allocator;
+import org.doorip.trip.domain.Todo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AllocatorRepository extends JpaRepository<Allocator, Long> {
+    List<Allocator> findByTodo(Todo todo);
+}


### PR DESCRIPTION
## Related Issue 📌
- close #140 

## Description ✔️
- 2차 스프린트 기능 중 여행 TODO 수정 API를 구현하였습니다.
- 여행 TODO 생성과 수정 데이터가 동일하여 기존에 사용하던 TodoCreateRequest를 TodoCreateAndUpdateRequest로 변경하여 재사용이 가능하도록 리팩터링하였습니다.
