### PR TITLE
[feat] 여행 정보 조회 API 구현

### DIFF
--- a/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
@@ -87,6 +87,13 @@ public class TripApiController implements TripApi {
         return ApiResponseUtil.success(SuccessMessage.OK);
     }
 
+    @GetMapping("/{tripId}")
+    public ResponseEntity<BaseResponse<?>> getTrip(@PathVariable final Long tripId,
+                                                      @UserId final Long userId) {
+        final TripGetResponse response = tripService.getTrip(userId, tripId);
+        return ApiResponseUtil.success(SuccessMessage.OK, response);
+    }
+
     @PatchMapping("/{tripId}")
     public ResponseEntity<BaseResponse<?>> updateTrip(@PathVariable final Long tripId,
                                                       @UserId final Long userId,

--- a/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
+++ b/doorip-api/src/main/java/org/doorip/trip/api/TripApiController.java
@@ -36,7 +36,7 @@ public class TripApiController implements TripApi {
     @Override
     public ResponseEntity<BaseResponse<?>> getTrips(@UserId final Long userId,
                                                     @RequestParam final String progress) {
-        final TripGetResponse response = tripService.getTrips(userId, progress);
+        final TripsGetResponse response = tripService.getTrips(userId, progress);
         return ApiResponseUtil.success(SuccessMessage.OK, response);
     }
 

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripGetResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripGetResponse.java
@@ -1,0 +1,28 @@
+package org.doorip.trip.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AccessLevel;
+import lombok.Builder;
+import org.doorip.trip.domain.Trip;
+
+import java.time.LocalDate;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record TripGetResponse(
+        Long tripId,
+        String title,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+        LocalDate startDate,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
+        LocalDate endDate
+) {
+
+    public static TripGetResponse of(Trip trip) {
+        return TripGetResponse.builder()
+                .tripId(trip.getId())
+                .title(trip.getTitle())
+                .startDate(trip.getStartDate())
+                .endDate(trip.getEndDate())
+                .build();
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripsGetResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripsGetResponse.java
@@ -7,12 +7,12 @@ import org.doorip.trip.domain.Trip;
 import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
-public record TripGetResponse(
+public record TripsGetResponse(
         String name,
         List<TripResponse> trips
 ) {
-    public static TripGetResponse of(String name, List<Trip> trips) {
-        return TripGetResponse.builder()
+    public static TripsGetResponse of(String name, List<Trip> trips) {
+        return TripsGetResponse.builder()
                 .name(name)
                 .trips(trips.stream()
                         .map(TripResponse::of)

--- a/doorip-api/src/main/java/org/doorip/trip/service/TripService.java
+++ b/doorip-api/src/main/java/org/doorip/trip/service/TripService.java
@@ -17,6 +17,7 @@ import org.doorip.trip.dto.response.TripCreateResponse;
 import org.doorip.trip.dto.response.TripEntryResponse;
 import org.doorip.trip.dto.response.TripGetResponse;
 import org.doorip.trip.dto.response.TripResponse;
+import org.doorip.trip.dto.response.TripsGetResponse;
 import org.doorip.trip.repository.ParticipantRepository;
 import org.doorip.trip.repository.TripRepository;
 import org.doorip.user.domain.User;
@@ -66,6 +67,13 @@ public class TripService {
     public TripResponse verifyCode(TripVerifyRequest request) {
         Trip trip = getTrip(request.code());
         return TripResponse.of(trip);
+    }
+
+    public TripGetResponse getTrip(Long userId, Long tripId) {
+        User findUser = getUser(userId);
+        Trip findTrip = getTrip(tripId);
+        validateParticipant(findUser, findTrip);
+        return TripGetResponse.of(findTrip);
     }
 
     @Transactional

--- a/doorip-api/src/main/java/org/doorip/trip/service/TripService.java
+++ b/doorip-api/src/main/java/org/doorip/trip/service/TripService.java
@@ -57,10 +57,10 @@ public class TripService {
         return TripEntryResponse.of(findTrip);
     }
 
-    public TripGetResponse getTrips(Long userId, String progress) {
+    public TripsGetResponse getTrips(Long userId, String progress) {
         User findUser = getUser(userId);
         List<Trip> trips = getTripsAccordingToProgress(userId, progress);
-        return TripGetResponse.of(findUser.getName(), trips);
+        return TripsGetResponse.of(findUser.getName(), trips);
     }
 
     public TripResponse verifyCode(TripVerifyRequest request) {


### PR DESCRIPTION
## Related Issue 📌
close #142 

## Description ✔️
- 여행 정보 조회 API를 구현하였습니다.
- 여행 정보 조회 응답 dto인 TripGetResponse를 구현하였습니다. 기존의 TripGetResponse는 여행 목록을 가져오는 response dto여서 TripsGetResponse로 변경하였습니다.
