### PR TITLE
[feat] 여행 친구 전체 조회 API 스펙 및 비즈니스 로직 변경

### DIFF
--- a/doorip-api/src/main/java/org/doorip/trip/actor/TripTendencyTestActor.java
+++ b/doorip-api/src/main/java/org/doorip/trip/actor/TripTendencyTestActor.java
@@ -1,0 +1,86 @@
+package org.doorip.trip.actor;
+
+import org.doorip.trip.domain.Participant;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+@Component
+public class TripTendencyTestActor {
+    private static final String TRIP_PLAN = "여행 계획";
+    private static final String TRIP_PLACE = "여행 장소";
+    private static final String RESTAURANT = "식당";
+    private static final String PICTURE = "사진";
+    private static final String TRIP_SCHEDULE = "여행 일정";
+    private static final int INITIALIZATION = 0;
+    private static final int HIGH_RANGE_STYLE = 3;
+    private static final int HIGH_RANGE_STYLES = 5;
+    private static final int CENTER_POS = 2;
+    private final Map<Integer, String> prefer = Map.of(
+            0, TRIP_PLAN,
+            1, TRIP_PLACE,
+            2, RESTAURANT,
+            3, PICTURE,
+            4, TRIP_SCHEDULE
+    );
+
+    public TripTendencyTestResult calculateTripTendencyTest(List<Participant> participants) {
+        List<List<Integer>> styles = generateStyles();
+        int participantCount = participants.size();
+        accumulateStyles(participants, styles);
+        List<String> bestPrefer = calculateBestPrefer(styles, participantCount);
+        calculateStyleAverage(styles, participantCount);
+        return TripTendencyTestResult.of(bestPrefer, styles);
+    }
+
+    private List<List<Integer>> generateStyles() {
+        List<List<Integer>> styles = new ArrayList<>();
+        IntStream.range(INITIALIZATION, HIGH_RANGE_STYLES)
+                .forEach(i -> styles.add(i, new ArrayList<>(Arrays.asList(INITIALIZATION, INITIALIZATION, INITIALIZATION))));
+        return styles;
+    }
+
+    private void accumulateStyles(List<Participant> participants, List<List<Integer>> styles) {
+        participants.forEach(participant -> {
+            accumulateStyle(styles, participant.getStyleA(), 0);
+            accumulateStyle(styles, participant.getStyleB(), 1);
+            accumulateStyle(styles, participant.getStyleC(), 2);
+            accumulateStyle(styles, participant.getStyleD(), 3);
+            accumulateStyle(styles, participant.getStyleE(), 4);
+        });
+    }
+
+    private List<String> calculateBestPrefer(List<List<Integer>> styles, int participantCount) {
+        List<String> bestPrefer = new ArrayList<>();
+        IntStream.range(INITIALIZATION, HIGH_RANGE_STYLES)
+                .forEach(i -> {
+                    List<Integer> style = styles.get(i);
+                    if (style.contains(participantCount)) {
+                        bestPrefer.add(prefer.get(i));
+                    }
+                });
+        return bestPrefer;
+    }
+
+    private void calculateStyleAverage(List<List<Integer>> styles, int participantCount) {
+        double percentage = 100.0 / participantCount;
+        styles.forEach(style ->
+                IntStream.range(INITIALIZATION, HIGH_RANGE_STYLE)
+                        .forEach(i -> style.set(i, (int) Math.floor(style.get(i) * percentage))));
+    }
+
+    private void accumulateStyle(List<List<Integer>> styles, int styleValue, int pos) {
+        List<Integer> style = styles.get(pos);
+        if (styleValue < CENTER_POS) {
+            style.set(0, style.get(0) + 1);
+        } else if (styleValue == CENTER_POS) {
+            style.set(1, style.get(1) + 1);
+        } else {
+            style.set(2, style.get(2) + 1);
+        }
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/trip/actor/TripTendencyTestResult.java
+++ b/doorip-api/src/main/java/org/doorip/trip/actor/TripTendencyTestResult.java
@@ -1,0 +1,12 @@
+package org.doorip.trip.actor;
+
+import java.util.List;
+
+public record TripTendencyTestResult(
+        List<String> bestPrefer,
+        List<List<Integer>> styles
+) {
+    public static TripTendencyTestResult of(List<String> bestPrefer, List<List<Integer>> styles) {
+        return new TripTendencyTestResult(bestPrefer, styles);
+    }
+}

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripParticipantGetResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripParticipantGetResponse.java
@@ -8,15 +8,19 @@ import java.util.List;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record TripParticipantGetResponse(
+        List<String> bestPrefer,
         List<TripParticipantResponse> participants,
         List<TripStyleResponse> styles
 ) {
-    public static TripParticipantGetResponse of(List<Participant> participants, List<TripStyleResponse> styles) {
+    public static TripParticipantGetResponse of(List<String> bestPrefer, List<Participant> participants, List<List<Integer>> styles) {
         return TripParticipantGetResponse.builder()
+                .bestPrefer(bestPrefer)
                 .participants(participants.stream()
                         .map(TripParticipantResponse::of)
                         .toList())
-                .styles(styles)
+                .styles(styles.stream()
+                        .map(TripStyleResponse::from)
+                        .toList())
                 .build();
     }
 }

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripParticipantResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripParticipantResponse.java
@@ -16,7 +16,7 @@ public record TripParticipantResponse(
         return TripParticipantResponse.builder()
                 .participantId(participant.getId())
                 .name(user.getName())
-                .result(user.getResult().getNumResult())
+                .result(user.getResult() == null ? -1 : user.getResult().getNumResult())
                 .build();
     }
 }

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripStyleResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripStyleResponse.java
@@ -1,17 +1,11 @@
 package org.doorip.trip.dto.response;
 
-import lombok.AccessLevel;
-import lombok.Builder;
+import java.util.List;
 
-@Builder(access = AccessLevel.PRIVATE)
 public record TripStyleResponse(
-        int rate,
-        boolean isLeft
+        List<Integer> rates
 ) {
-    public static TripStyleResponse of(int rate, boolean isLeft) {
-        return TripStyleResponse.builder()
-                .rate(rate)
-                .isLeft(isLeft)
-                .build();
+    public static TripStyleResponse from(List<Integer> rates) {
+        return new TripStyleResponse(rates);
     }
 }


### PR DESCRIPTION
## Related Issue 📌
- close #146 

## Description ✔️
- 2차 스프린트 기능 변경 사항을 반영하여 여행 친구 전체 조회 API 비즈니스 로직을 변경하였습니다.
- 여행 성향 테스트 결과 통계를 계산하는 로직을 Actor 클래스로 분리하였습니다.
- 여행 성향 테스트 결과 통계를 계산하는 모든 책임은 TripTendencyTestActor 클래스가 가지며 서비스 클래스에서 해당 Actor 클래스로 계산을 위임한 후 TripTendencyTestResult 라는 결과만을 받아 사용할 수 있도록 리팩터링하였습니다.
- Actor 클래스로 분리한 이유는 다음과 같습니다.
- 1. 기존에 서비스 계층에 모든 관심사가 섞여있어 여행 성향 테스트 결과 통계 계산 로직을 구분하기 힘든 불편함이 있었습니다. 해당 로직을 구분하기 힘들어 이번처럼 기능 수정이 필요할 때 개발 비용이 많이 든다고 느껴졌습니다.
- 2. 마찬가지로 서비스 계층에 모든 관심사가 섞여있어 여행 성향 테스트 결과 통계 계산 로직에 대한 테스트 코드를 작성하기 어렵다고 느껴졌고 하나의 서비스 클래스가 너무 많은 책임을 가지고 있다고 판단되어 분리하였습니다.