### PR TITLE
[fix] 여행 친구 전체 조회 API 스펙 변경

### DIFF
--- a/doorip-api/src/main/java/org/doorip/common/Constants.java
+++ b/doorip-api/src/main/java/org/doorip/common/Constants.java
@@ -8,15 +8,9 @@ public abstract class Constants {
     public static final String COMPLETE = "complete";
     public static final String OUR = "our";
     public static final String MY = "my";
-    public static final String STYLE_A = "style_a";
-    public static final String STYLE_B = "style_b";
-    public static final String STYLE_C = "style_c";
-    public static final String STYLE_D = "style_d";
-    public static final String STYLE_E = "style_e";
-    public static final int MIN_STYLE_RATE = 0;
-    public static final int MAX_STYLE_RATE = 100;
-    public static final int PROPENSITY_WEIGHT = 25;
-    public static final int MAX_PARTICIPANT_COUNT = 6;
     public static final int MIN_PARTICIPANT_COUNT = 1;
+    public static final int MAX_PARTICIPANT_COUNT = 6;
     public static final int TODO_OWNER_POSITION = 0;
+    public static final int START_STYLE_POS = 0;
+    public static final int END_STYLE_POS = 5;
 }

--- a/doorip-api/src/main/java/org/doorip/trip/actor/TripTendencyTestActor.java
+++ b/doorip-api/src/main/java/org/doorip/trip/actor/TripTendencyTestActor.java
@@ -29,12 +29,13 @@ public class TripTendencyTestActor {
     );
 
     public TripTendencyTestResult calculateTripTendencyTest(List<Participant> participants) {
-        List<List<Integer>> styles = generateStyles();
+        List<List<Integer>> rates = generateStyles();
+        List<List<Integer>> counts = generateStyles();
         int participantCount = participants.size();
-        accumulateStyles(participants, styles);
-        List<String> bestPrefer = calculateBestPrefer(styles, participantCount);
-        calculateStyleAverage(styles, participantCount);
-        return TripTendencyTestResult.of(bestPrefer, styles);
+        accumulateCounts(participants, counts);
+        List<String> bestPrefer = calculateBestPrefer(counts, participantCount);
+        calculateRatesAverage(rates, counts, participantCount);
+        return TripTendencyTestResult.of(bestPrefer, rates, counts);
     }
 
     private List<List<Integer>> generateStyles() {
@@ -44,43 +45,47 @@ public class TripTendencyTestActor {
         return styles;
     }
 
-    private void accumulateStyles(List<Participant> participants, List<List<Integer>> styles) {
+    private void accumulateCounts(List<Participant> participants, List<List<Integer>> counts) {
         participants.forEach(participant -> {
-            accumulateStyle(styles, participant.getStyleA(), 0);
-            accumulateStyle(styles, participant.getStyleB(), 1);
-            accumulateStyle(styles, participant.getStyleC(), 2);
-            accumulateStyle(styles, participant.getStyleD(), 3);
-            accumulateStyle(styles, participant.getStyleE(), 4);
+            accumulateCount(counts, participant.getStyleA(), 0);
+            accumulateCount(counts, participant.getStyleB(), 1);
+            accumulateCount(counts, participant.getStyleC(), 2);
+            accumulateCount(counts, participant.getStyleD(), 3);
+            accumulateCount(counts, participant.getStyleE(), 4);
         });
     }
 
-    private List<String> calculateBestPrefer(List<List<Integer>> styles, int participantCount) {
+    private List<String> calculateBestPrefer(List<List<Integer>> counts, int participantCount) {
         List<String> bestPrefer = new ArrayList<>();
         IntStream.range(INITIALIZATION, HIGH_RANGE_STYLES)
                 .forEach(i -> {
-                    List<Integer> style = styles.get(i);
-                    if (style.contains(participantCount)) {
+                    List<Integer> count = counts.get(i);
+                    if (count.contains(participantCount)) {
                         bestPrefer.add(prefer.get(i));
                     }
                 });
         return bestPrefer;
     }
 
-    private void calculateStyleAverage(List<List<Integer>> styles, int participantCount) {
+    private void calculateRatesAverage(List<List<Integer>> rates, List<List<Integer>> counts, int participantCount) {
         double percentage = 100.0 / participantCount;
-        styles.forEach(style ->
-                IntStream.range(INITIALIZATION, HIGH_RANGE_STYLE)
-                        .forEach(i -> style.set(i, (int) Math.floor(style.get(i) * percentage))));
+        IntStream.range(INITIALIZATION, HIGH_RANGE_STYLES)
+                .forEach(i -> {
+                    List<Integer> rate = rates.get(i);
+                    List<Integer> count = counts.get(i);
+                    IntStream.range(INITIALIZATION, HIGH_RANGE_STYLE)
+                            .forEach(j -> rate.set(j, (int) Math.floor(count.get(j) * percentage)));
+                });
     }
 
-    private void accumulateStyle(List<List<Integer>> styles, int styleValue, int pos) {
-        List<Integer> style = styles.get(pos);
+    private void accumulateCount(List<List<Integer>> counts, int styleValue, int pos) {
+        List<Integer> count = counts.get(pos);
         if (styleValue < CENTER_POS) {
-            style.set(0, style.get(0) + 1);
+            count.set(0, count.get(0) + 1);
         } else if (styleValue == CENTER_POS) {
-            style.set(1, style.get(1) + 1);
+            count.set(1, count.get(1) + 1);
         } else {
-            style.set(2, style.get(2) + 1);
+            count.set(2, count.get(2) + 1);
         }
     }
 }

--- a/doorip-api/src/main/java/org/doorip/trip/actor/TripTendencyTestResult.java
+++ b/doorip-api/src/main/java/org/doorip/trip/actor/TripTendencyTestResult.java
@@ -1,12 +1,21 @@
 package org.doorip.trip.actor;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+
 import java.util.List;
 
+@Builder(access = AccessLevel.PRIVATE)
 public record TripTendencyTestResult(
         List<String> bestPrefer,
-        List<List<Integer>> styles
+        List<List<Integer>> rates,
+        List<List<Integer>> counts
 ) {
-    public static TripTendencyTestResult of(List<String> bestPrefer, List<List<Integer>> styles) {
-        return new TripTendencyTestResult(bestPrefer, styles);
+    public static TripTendencyTestResult of(List<String> bestPrefer, List<List<Integer>> rates, List<List<Integer>> counts) {
+        return TripTendencyTestResult.builder()
+                .bestPrefer(bestPrefer)
+                .rates(rates)
+                .counts(counts)
+                .build();
     }
 }

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripParticipantGetResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripParticipantGetResponse.java
@@ -2,9 +2,12 @@ package org.doorip.trip.dto.response;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import org.doorip.common.Constants;
 import org.doorip.trip.domain.Participant;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 
 @Builder(access = AccessLevel.PRIVATE)
 public record TripParticipantGetResponse(
@@ -12,15 +15,16 @@ public record TripParticipantGetResponse(
         List<TripParticipantResponse> participants,
         List<TripStyleResponse> styles
 ) {
-    public static TripParticipantGetResponse of(List<String> bestPrefer, List<Participant> participants, List<List<Integer>> styles) {
+    public static TripParticipantGetResponse of(List<String> bestPrefer, List<Participant> participants, List<List<Integer>> rates, List<List<Integer>> counts) {
+        List<TripStyleResponse> styles = new ArrayList<>();
+        IntStream.range(Constants.START_STYLE_POS, Constants.END_STYLE_POS)
+                .forEach(i -> styles.add(TripStyleResponse.of(rates.get(i), counts.get(i))));
         return TripParticipantGetResponse.builder()
                 .bestPrefer(bestPrefer)
                 .participants(participants.stream()
                         .map(TripParticipantResponse::of)
                         .toList())
-                .styles(styles.stream()
-                        .map(TripStyleResponse::from)
-                        .toList())
+                .styles(styles)
                 .build();
     }
 }

--- a/doorip-api/src/main/java/org/doorip/trip/dto/response/TripStyleResponse.java
+++ b/doorip-api/src/main/java/org/doorip/trip/dto/response/TripStyleResponse.java
@@ -3,9 +3,10 @@ package org.doorip.trip.dto.response;
 import java.util.List;
 
 public record TripStyleResponse(
-        List<Integer> rates
+        List<Integer> rates,
+        List<Integer> counts
 ) {
-    public static TripStyleResponse from(List<Integer> rates) {
-        return new TripStyleResponse(rates);
+    public static TripStyleResponse of(List<Integer> rates, List<Integer> counts) {
+        return new TripStyleResponse(rates, counts);
     }
 }

--- a/doorip-api/src/main/java/org/doorip/trip/service/TripDetailService.java
+++ b/doorip-api/src/main/java/org/doorip/trip/service/TripDetailService.java
@@ -61,7 +61,7 @@ public class TripDetailService {
         Participant ownerParticipant = getOwnerParticipant(userId, participants);
         sortParticipants(participants, ownerParticipant);
         TripTendencyTestResult result = tripTendencyTestActor.calculateTripTendencyTest(participants);
-        return TripParticipantGetResponse.of(result.bestPrefer(), participants, result.styles());
+        return TripParticipantGetResponse.of(result.bestPrefer(), participants, result.rates(), result.counts());
     }
 
     @Transactional
@@ -166,8 +166,7 @@ public class TripDetailService {
     private int getValidatedResult(User user) {
         if (user.getResult() == null) {
             return -1;
-        }
-        else {
+        } else {
             return user.getResult().getNumResult();
         }
     }


### PR DESCRIPTION
## Related Issue 📌
- close #151 

## Description ✔️
- 여행 친구 전체 조회 시 성향 검사 결과에 누락된 속성이 있어서 해당 속성을 추가하였습니다. (선택지 사람 수)
- 속성이 추가됨에 따라 여행 친구 전체 조회 API 스펙이 변경되었습니다.
