### PR TITLE
[fix] 중복 회원가입 동시성 문제 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 ### Yml ###
 doorip-api/src/main/resources/application.yml
+doorip-api/src/test/resources/application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ subprojects {
 
 		// test
 		testImplementation 'org.springframework.boot:spring-boot-starter-test'
+		testCompileOnly 'org.projectlombok:lombok'
+		testAnnotationProcessor 'org.projectlombok:lombok'
 	}
 
 	tasks.named('test') {

--- a/doorip-api/src/main/java/org/doorip/common/Constants.java
+++ b/doorip-api/src/main/java/org/doorip/common/Constants.java
@@ -13,4 +13,5 @@ public abstract class Constants {
     public static final int TODO_OWNER_POSITION = 0;
     public static final int START_STYLE_POS = 0;
     public static final int END_STYLE_POS = 5;
+    public static final String SIGN_UP_LOCK = "signup";
 }

--- a/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
+++ b/doorip-api/src/main/java/org/doorip/user/api/UserApiController.java
@@ -2,18 +2,14 @@ package org.doorip.user.api;
 
 import lombok.RequiredArgsConstructor;
 import org.doorip.auth.UserId;
-import org.doorip.common.BaseResponse;
 import org.doorip.common.ApiResponseUtil;
+import org.doorip.common.BaseResponse;
 import org.doorip.message.SuccessMessage;
-import org.doorip.user.dto.request.ResultUpdateRequest;
-import org.doorip.user.dto.request.UserReissueRequest;
-import org.doorip.user.dto.request.UserSignInRequest;
-import org.doorip.user.dto.request.UserSignUpRequest;
-import org.doorip.user.dto.request.ProfileUpdateRequest;
+import org.doorip.user.dto.request.*;
 import org.doorip.user.dto.response.ProfileGetResponse;
-import org.doorip.user.dto.response.UserSignUpResponse;
 import org.doorip.user.dto.response.UserSignInResponse;
-import org.doorip.user.service.UserService;
+import org.doorip.user.dto.response.UserSignUpResponse;
+import org.doorip.user.facade.UserFacade;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -24,12 +20,12 @@ import static org.doorip.common.Constants.AUTHORIZATION;
 @RequestMapping("/api/users")
 @Controller
 public class UserApiController implements UserApi {
-    private final UserService userService;
+    private final UserFacade userFacade;
 
     @GetMapping("/splash")
     @Override
     public ResponseEntity<BaseResponse<?>> splash(@UserId final Long userId) {
-        userService.splash(userId);
+        userFacade.splash(userId);
         return ApiResponseUtil.success(SuccessMessage.OK);
     }
 
@@ -37,7 +33,7 @@ public class UserApiController implements UserApi {
     @Override
     public ResponseEntity<BaseResponse<?>> signIn(@RequestHeader(AUTHORIZATION) final String token,
                                                   @RequestBody final UserSignInRequest request) {
-        final UserSignInResponse response = userService.signIn(token, request);
+        final UserSignInResponse response = userFacade.signIn(token, request);
         return ApiResponseUtil.success(SuccessMessage.OK, response);
     }
 
@@ -45,21 +41,21 @@ public class UserApiController implements UserApi {
     @Override
     public ResponseEntity<BaseResponse<?>> signUp(@RequestHeader(AUTHORIZATION) final String token,
                                                   @RequestBody final UserSignUpRequest request) {
-        final UserSignUpResponse response = userService.signUp(token, request);
+        final UserSignUpResponse response = userFacade.signUp(token, request);
         return ApiResponseUtil.success(SuccessMessage.CREATED, response);
     }
 
     @PatchMapping("/signout")
     @Override
     public ResponseEntity<BaseResponse<?>> signOut(@UserId final Long userId) {
-        userService.signOut(userId);
+        userFacade.signOut(userId);
         return ApiResponseUtil.success(SuccessMessage.OK);
     }
 
     @DeleteMapping("/withdraw")
     @Override
     public ResponseEntity<BaseResponse<?>> withdraw(@UserId final Long userId) {
-        userService.withdraw(userId);
+        userFacade.withdraw(userId);
         return ApiResponseUtil.success(SuccessMessage.OK);
     }
 
@@ -67,14 +63,14 @@ public class UserApiController implements UserApi {
     @Override
     public ResponseEntity<BaseResponse<?>> reissue(@RequestHeader(AUTHORIZATION) final String refreshtoken,
                                                    @RequestBody final UserReissueRequest request) {
-        final UserSignUpResponse response = userService.reissue(refreshtoken, request);
+        final UserSignUpResponse response = userFacade.reissue(refreshtoken, request);
         return ApiResponseUtil.success(SuccessMessage.OK, response);
     }
 
     @GetMapping("/profile")
     @Override
     public ResponseEntity<BaseResponse<?>> getProfile(@UserId final Long userId) {
-        final ProfileGetResponse response = userService.getProfile(userId);
+        final ProfileGetResponse response = userFacade.getProfile(userId);
         return ApiResponseUtil.success(SuccessMessage.OK, response);
     }
 
@@ -82,14 +78,14 @@ public class UserApiController implements UserApi {
     @Override
     public ResponseEntity<BaseResponse<?>> updateResult(@UserId final Long userId,
                                                         @RequestBody final ResultUpdateRequest request) {
-        userService.updateResult(userId, request);
+        userFacade.updateResult(userId, request);
         return ApiResponseUtil.success(SuccessMessage.OK);
     }
 
     @PatchMapping("/profile")
     public ResponseEntity<BaseResponse<?>> updateProfile(@UserId final Long userId,
                                                          @RequestBody final ProfileUpdateRequest request) {
-        userService.updateProfile(userId, request);
+        userFacade.updateProfile(userId, request);
         return ApiResponseUtil.success(SuccessMessage.OK);
     }
 }

--- a/doorip-api/src/main/java/org/doorip/user/facade/UserFacade.java
+++ b/doorip-api/src/main/java/org/doorip/user/facade/UserFacade.java
@@ -1,0 +1,65 @@
+package org.doorip.user.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.doorip.common.Constants;
+import org.doorip.user.dto.request.*;
+import org.doorip.user.dto.response.ProfileGetResponse;
+import org.doorip.user.dto.response.UserSignInResponse;
+import org.doorip.user.dto.response.UserSignUpResponse;
+import org.doorip.user.repository.LettuceLockRepository;
+import org.doorip.user.service.UserService;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+public class UserFacade {
+    private final UserService userService;
+    private final LettuceLockRepository lettuceLockRepository;
+
+    public void splash(Long userId) {
+        userService.splash(userId);
+    }
+
+    public UserSignInResponse signIn(String token, UserSignInRequest request) {
+        return userService.signIn(token, request);
+    }
+
+    public UserSignUpResponse signUp(String token, UserSignUpRequest request) {
+        while (!lettuceLockRepository.lock(token, Constants.SIGN_UP_LOCK)) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        try {
+            return userService.signUp(token, request);
+        } finally {
+            lettuceLockRepository.unlock(token);
+        }
+    }
+
+    public void signOut(Long userId) {
+        userService.signOut(userId);
+    }
+
+    public void withdraw(Long userId) {
+        userService.withdraw(userId);
+    }
+
+    public UserSignUpResponse reissue(String refreshToken, UserReissueRequest request) {
+        return userService.reissue(refreshToken, request);
+    }
+
+    public ProfileGetResponse getProfile(Long userId) {
+        return userService.getProfile(userId);
+    }
+
+    public void updateResult(Long userId, ResultUpdateRequest request) {
+        userService.updateResult(userId, request);
+    }
+
+    public void updateProfile(Long userId, ProfileUpdateRequest request) {
+        userService.updateProfile(userId, request);
+    }
+}

--- a/doorip-api/src/test/java/org/doorip/user/facade/UserFacadeTest.java
+++ b/doorip-api/src/test/java/org/doorip/user/facade/UserFacadeTest.java
@@ -1,0 +1,77 @@
+package org.doorip.user.facade;
+
+import lombok.extern.slf4j.Slf4j;
+import org.doorip.exception.ConflictException;
+import org.doorip.exception.EntityNotFoundException;
+import org.doorip.message.ErrorMessage;
+import org.doorip.user.dto.request.UserSignInRequest;
+import org.doorip.user.dto.request.UserSignUpRequest;
+import org.doorip.user.dto.response.UserSignInResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Slf4j
+@SpringBootTest
+class UserFacadeTest {
+    @Autowired
+    UserFacade userFacade;
+    @Value("${oauth.kakao.test}")
+    String accessToken;
+
+    @AfterEach
+    void afterEach() {
+        UserSignInRequest request = new UserSignInRequest("kakao");
+        try {
+            UserSignInResponse response = userFacade.signIn(accessToken, request);
+            userFacade.withdraw(response.userId());
+        } catch (EntityNotFoundException e) {
+            log.error("After Each Error: ", e);
+            throw e;
+        }
+    }
+
+    @DisplayName("동일한 회원의 회원가입 요청이 동시에 여러 개 들어오는 경우 정상적으로 회원가입된다.")
+    @Test
+    void 동일한_회원의_회원가입_요청이_동시에_여러_개_들어오는_경우_정상적으로_회원가입된다() throws InterruptedException {
+        // given
+        int threadCount = 20;
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        UserSignUpRequest signUpRequest = new UserSignUpRequest("개발자", "동시성 테스트", "kakao");
+        UserSignInRequest signInRequest = new UserSignInRequest("kakao");
+
+        // when
+        IntStream.range(0, threadCount)
+                .forEach(i ->
+                        executorService.submit(() -> {
+                            try {
+                                userFacade.signUp(accessToken, signUpRequest);
+                            } catch (ConflictException e) {
+                                log.error("Sub Task Thread Error: ", e);
+                                throw e;
+                            } finally {
+                                latch.countDown();
+                            }
+                        }));
+        latch.await();
+
+        // then
+        assertThatThrownBy(() -> userFacade.signUp(accessToken, signUpRequest))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage(ErrorMessage.DUPLICATE_USER.getMessage());
+        UserSignInResponse response = userFacade.signIn(accessToken, signInRequest);
+        assertThat(response.userId()).isNotNull();
+    }
+}

--- a/doorip-domain/src/main/java/org/doorip/user/repository/LettuceLockRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/user/repository/LettuceLockRepository.java
@@ -1,0 +1,23 @@
+package org.doorip.user.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Repository
+public class LettuceLockRepository {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public Boolean lock(String token, String lockType) {
+        return redisTemplate
+                .opsForValue()
+                .setIfAbsent(token, lockType, Duration.ofSeconds(3L));
+    }
+
+    public void unlock(String token) {
+        redisTemplate.delete(token);
+    }
+}


### PR DESCRIPTION
## Related Issue 📌
- close #156 

## Description ✔️

### 중복 회원가입 동시성 문제
회원가입 비즈니스 로직에 디스코드 웹훅 기능을 추가한 후 처리 시간이 길어져 동시 요청 시 중복 회원가입 되는 문제점이 발생했습니다.
즉, 회원가입 로직의 처리 시간이 증가하여 특정 사용자가 회원가입 버튼을 클릭하고 대략 1초 정도의 딜레이 시간이 생기게 되었고 해당 딜레이 시간 동안 버튼을 연속으로 클릭 시 중복으로 회원가입 처리 되었습니다.

### 해결방안
회원가입 로직을 임계 영역으로 두고 race condition이 발생하지 않도록 락을 활용하여 문제를 해결할 수 있었습니다.
문제를 해결하기 위해 고민했던 락은 Pessimistic Lock, Optimistic Lock, Lettuce Setnx Lock 세 가지였습니다.
저희 서비스는 refresh token 저장 용도로 레디스를 사용 중이기 때문에 추가적인 인프라 구축 비용이 들지 않는점 그리고 DB 접근보다 레디스 접근이 조금 더 높은 성능을 가져올 수 있어 사용자의 대기 시간을 최대한 줄일 수 있다고 생각되어 Lettuce Setnx Lock을 활용하였습니다. 또한 락을 걸고 해제하는 작업을 위해 파사드 패턴을 적용하였습니다.
동일한 사용자의 약 20개 회원가입 동시 요청에 대한 테스트 코드를 작성하였습니다.
<img width="595" src="https://github.com/Team-Going/Going-Server/assets/81796317/417ef386-cbf7-4e19-a521-b9755fd72af2">
