### PR TITLE
[refactor] 디스코드 웹훅 알림 비동기 이벤트로 리팩터링

### DIFF
--- a/doorip-api/build.gradle
+++ b/doorip-api/build.gradle
@@ -14,6 +14,8 @@ dependencies {
     implementation project(path: ':doorip-domain')
     implementation project(path: ':doorip-external')
     implementation project(path: ':doorip-common')
+    implementation project(path: ':doorip-event-publisher')
+    implementation project(path: ':doorip-event-subscriber')
 }
 
 jar {

--- a/doorip-api/src/main/java/org/doorip/DooripApplication.java
+++ b/doorip-api/src/main/java/org/doorip/DooripApplication.java
@@ -3,9 +3,7 @@ package org.doorip;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@SpringBootApplication(
-        scanBasePackageClasses = {DomainRoot.class, CommonRoot.class, ExternalRoot.class}
-)
+@SpringBootApplication
 public class DooripApplication {
     public static void main(String[] args) {
         SpringApplication.run(DooripApplication.class, args);

--- a/doorip-common/src/main/java/org/doorip/CommonRoot.java
+++ b/doorip-common/src/main/java/org/doorip/CommonRoot.java
@@ -1,4 +1,0 @@
-package org.doorip;
-
-public interface CommonRoot {
-}

--- a/doorip-common/src/main/java/org/doorip/event/SignUpEvent.java
+++ b/doorip-common/src/main/java/org/doorip/event/SignUpEvent.java
@@ -1,0 +1,13 @@
+package org.doorip.event;
+
+import org.doorip.message.EventMessage;
+
+public record SignUpEvent(
+        EventMessage eventMessage,
+        String name,
+        int count
+) {
+    public static SignUpEvent of(EventMessage eventMessage, String name, int count) {
+        return new SignUpEvent(eventMessage, name, count);
+    }
+}

--- a/doorip-common/src/main/java/org/doorip/message/EventMessage.java
+++ b/doorip-common/src/main/java/org/doorip/message/EventMessage.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public enum EventMessage {
-    SIGN_UP_EVENT("doorip 서비스에 회원가입 이벤트가 발생했습니다. 🎉");
+    SIGN_UP_EVENT("[🎉 doorip 회원가입 🎉]\n>> 닉네임: [%s]\n>> 현재 가입자 수: [%d명]");
 
     private final String message;
 }

--- a/doorip-domain/src/main/java/org/doorip/DomainRoot.java
+++ b/doorip-domain/src/main/java/org/doorip/DomainRoot.java
@@ -1,4 +1,0 @@
-package org.doorip;
-
-public interface DomainRoot {
-}

--- a/doorip-domain/src/main/java/org/doorip/user/repository/UserRepository.java
+++ b/doorip-domain/src/main/java/org/doorip/user/repository/UserRepository.java
@@ -3,6 +3,7 @@ package org.doorip.user.repository;
 import org.doorip.user.domain.Platform;
 import org.doorip.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
@@ -10,4 +11,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findUserByPlatformAndPlatformId(Platform platform, String platformId);
 
     boolean existsUserByPlatformAndPlatformId(Platform platform, String platformId);
+
+    @Query("select count(*) from User u")
+    int countUser();
 }

--- a/doorip-event-publisher/build.gradle
+++ b/doorip-event-publisher/build.gradle
@@ -1,0 +1,12 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation project(path: ':doorip-common')
+}
+
+bootJar {
+    enabled = false
+}
+
+jar {
+    enabled = true
+}

--- a/doorip-event-publisher/src/main/java/org/doorip/publisher/EventPublisher.java
+++ b/doorip-event-publisher/src/main/java/org/doorip/publisher/EventPublisher.java
@@ -1,0 +1,19 @@
+package org.doorip.publisher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.doorip.event.SignUpEvent;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class EventPublisher {
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publishSignUpEvent(SignUpEvent event) {
+        log.info("[publish] sign up event {}", event);
+        eventPublisher.publishEvent(event);
+    }
+}

--- a/doorip-event-subscriber/build.gradle
+++ b/doorip-event-subscriber/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation project(path: ':doorip-common')
+    implementation project(path: ':doorip-external')
+}
+
+bootJar {
+    enabled = false
+}
+
+jar {
+    enabled = true
+}

--- a/doorip-event-subscriber/src/main/java/org/doorip/config/AsyncConfig.java
+++ b/doorip-event-subscriber/src/main/java/org/doorip/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package org.doorip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+    @Bean
+    public Executor threadPoolTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(3);
+        executor.setMaxPoolSize(30);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("async-executor-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/doorip-event-subscriber/src/main/java/org/doorip/subscriber/EventSubscriber.java
+++ b/doorip-event-subscriber/src/main/java/org/doorip/subscriber/EventSubscriber.java
@@ -1,0 +1,26 @@
+package org.doorip.subscriber;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.doorip.event.SignUpEvent;
+import org.doorip.message.EventMessage;
+import org.doorip.openfeign.discord.DiscordMessageProvider;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class EventSubscriber {
+    private final DiscordMessageProvider discordMessageProvider;
+
+    @Async
+    @EventListener
+    public void subscribeSignUpEvent(SignUpEvent event) {
+        log.info("[subscribe] sign up event {}", event);
+        EventMessage eventMessage = event.eventMessage();
+        String message = String.format(eventMessage.getMessage(), event.name(), event.count());
+        discordMessageProvider.sendMessage(message);
+    }
+}

--- a/doorip-external/src/main/java/org/doorip/ExternalRoot.java
+++ b/doorip-external/src/main/java/org/doorip/ExternalRoot.java
@@ -1,4 +1,0 @@
-package org.doorip;
-
-public interface ExternalRoot {
-}

--- a/doorip-external/src/main/java/org/doorip/config/FeignClientConfig.java
+++ b/doorip-external/src/main/java/org/doorip/config/FeignClientConfig.java
@@ -1,10 +1,9 @@
 package org.doorip.config;
 
-import org.doorip.ExternalRoot;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableFeignClients(basePackageClasses = ExternalRoot.class)
+@EnableFeignClients(basePackages = "org.doorip")
 public class FeignClientConfig {
 }

--- a/doorip-external/src/main/java/org/doorip/openfeign/discord/DiscordMessageProvider.java
+++ b/doorip-external/src/main/java/org/doorip/openfeign/discord/DiscordMessageProvider.java
@@ -4,7 +4,6 @@ import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.doorip.exception.InvalidValueException;
 import org.doorip.message.ErrorMessage;
-import org.doorip.message.EventMessage;
 import org.springframework.stereotype.Component;
 
 import static org.doorip.openfeign.discord.DiscordMessage.createDiscordMessage;
@@ -14,8 +13,8 @@ import static org.doorip.openfeign.discord.DiscordMessage.createDiscordMessage;
 public class DiscordMessageProvider {
     private final DiscordFeignClient discordFeignClient;
 
-    public void sendMessage(EventMessage eventMessage) {
-        DiscordMessage discordMessage = createDiscordMessage(eventMessage.getMessage());
+    public void sendMessage(String message) {
+        DiscordMessage discordMessage = createDiscordMessage(message);
         sendMessageToDiscord(discordMessage);
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,3 +3,6 @@ include 'doorip-api'
 include 'doorip-domain'
 include 'doorip-common'
 include 'doorip-external'
+include 'doorip-event-publisher'
+include 'doorip-event-subscriber'
+


### PR DESCRIPTION
## Related Issue 📌
- close #160 #153 

## Description ✔️
### 중복 회원가입 동시성 문제가 발생하게 된 주요한 원인
앱 내에서 회원가입 버튼 클릭 시 약 0.7초 정도의 딜레이 시간이 발생했고 해당 시간 동안 사용자가 버튼을 연속으로 클릭하면 동시에 여러 요청이 들어와 첫번째 요청이 처리되기 전 두번째 요청이 수행되어 중복 회원 검증 로직이 예상했던 결과와 다르게 동작하게 되고 결국 서비스에 동일한 회원이 2명 이상 존재하게 되는 문제였습니다. 이유는 race condition이 발생했기 때문이라고 판단했고 이를 해결하기 위해 회원가입 로직을 임계 영역으로 두고 setnx 락을 사용하여 해결하였습니다. 그러나 회원가입 버튼을 클릭한 이후 API 통신의 응답을 받기까지 약 0.5 ~ 0.7초 정도의 딜레이 시간은 사용자 입장에서 앱이 먹통되어 정상적으로 동작하고 있지 않다고 느껴질 것이고 이에 따라 자연스럽게 회원가입 버튼을 여러 번 클릭하게 끔 유도된다고 생각되었습니다. 따라서 락을 사용하여 race condition을 방지하되, API 통신의 딜레이 시간을 최소화할 수 있는 방법을 도입해야 한다고 판단되었습니다. 

### 해결방안
현재 회원가입 비즈니스 로직에서 소요시간의 비중이 가장 큰 기능은 외부 API 통신이 수행되는 디스코드 웹훅 알림 기능이었습니다. 디스코드 웹훅 알림 기능은 회원가입 비즈니스 로직에서 동기적으로 동작하지 않아도 되는 기능이라고 판단되었고 이를 비동기 방식으로 리팩터링하여 회원가입 API 통신의 딜레이 시간을 단축시키고자 하였습니다.
ApplicationEventPublisher와 @EventListener 그리고 @Async 어노테이션을 적용하여 디스코드 웹훅 알림 기능을 비동기 이벤트 방식으로 리팩터링을 진행하였습니다.
스프링 이벤트 기능을 도입하면서 어떤 모듈 그리고 패키지에 해당 클래스들을 두어야 할지 고민하였습니다. 초기 설계는 회원가입 로직이 수행되는 doorip-api 모듈에는 EventPublisher, 디스코드 웹훅 알림 기능이 수행되는 doorip-external 모듈에는 EventSubscriber를 두어 구현을 하였습니다. 그러나 EventPublisher와 EventSubscriber는 각 모듈이 가진 관심사와 다른 관심사라고 판단되어 doorip-event-publisher, doorip-event-subscriber 모듈로 각각 분리하여 적용하였습니다. 모듈을 분리하는게 옳은 방향인지는 아직 고민 중이며 전체적인 모듈 간의 의존성을 파악하고 지속적으로 개선해나가려고 합니다.
스프링 이벤트 기반을 비동기 방식으로 구현하기 위해 @Async 어노테이션을 적용하였습니다. 단, @Async 어노테이션의 기본 설정은 SimpleAsyncTaskExecutor를 사용하여 요청마다 스레드가 생성되는 방식이기 때문에 무분별하게 스레드가 생성되어 관리되지 못하는 문제가 생길 수 있다고 판단되어 ThreadPoolTaskExecutor를 활용한 스레드 풀 방식으로 구현하였습니다.

@Async 어노테이션 적용 X(동기 방식)
<img width="308" src="https://github.com/Team-Going/Going-Server/assets/81796317/8353c3fa-05f3-4ecd-8cb1-27987dac17b9">

@Async 어노테이션 적용 O(비동기 방식)
<img width="308" src="https://github.com/Team-Going/Going-Server/assets/81796317/775126ac-05ae-49a5-8bf6-cab07ce41780">
<img width="511" src="https://github.com/Team-Going/Going-Server/assets/81796317/a7a68505-c656-423f-b7a7-dee5a8c34550">

결론은 다음과 같습니다. 디스코드 알림 기능에 총 가입자 수를 카운팅하는 기능까지 추가하여 동기 방식으로 API 통신이 수행되었을 때 약 0.9초의 딜레이 시간이 발생했고 이를 비동기 이벤트 기반으로 리팩터링하여 약 0.18초까지 단축할 수 있었습니다.
